### PR TITLE
Add description search, shared/favorite filters, and ticket editing

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ Simple Flask app for tracking tickets with:
 - date
 - checkbox for "shared with manager"
 - checkbox for favorites
+- description search
+- filters for shared/favorite tickets
+- in-place editing of existing tickets
 
 ## Run
 

--- a/app.py
+++ b/app.py
@@ -55,14 +55,52 @@ def init_db() -> None:
     db.close()
 
 
+def _validated_ticket_fields(form: Any) -> tuple[str, str, str, str, int, int] | None:
+    link = form.get("link", "").strip()
+    category_id = form.get("category_id", "").strip()
+    description = form.get("description", "").strip()
+    date_value = form.get("date", "").strip()
+    shared_with_manager = 1 if form.get("shared_with_manager") == "on" else 0
+    favorite = 1 if form.get("favorite") == "on" else 0
+
+    if not link or not category_id or not description or not date_value:
+        return None
+
+    try:
+        datetime.strptime(date_value, "%Y-%m-%d")
+    except ValueError:
+        return None
+
+    return link, category_id, description, date_value, shared_with_manager, favorite
+
+
 @app.route("/", methods=["GET"])
 def index() -> str:
     sort_by = request.args.get("sort_by", "date")
     order = request.args.get("order", "desc")
+    description_search = request.args.get("q", "").strip()
+    shared_only = request.args.get("shared_only", "0") == "1"
+    favorite_only = request.args.get("favorite_only", "0") == "1"
+    edit_id = request.args.get("edit_id", "").strip()
 
     allowed_sort = {"date": "t.date", "category": "c.name"}
     sort_column = allowed_sort.get(sort_by, "t.date")
     sort_order = "ASC" if order == "asc" else "DESC"
+
+    where_clauses: list[str] = []
+    params: list[Any] = []
+
+    if description_search:
+        where_clauses.append("LOWER(t.description) LIKE ?")
+        params.append(f"%{description_search.lower()}%")
+
+    if shared_only:
+        where_clauses.append("t.shared_with_manager = 1")
+
+    if favorite_only:
+        where_clauses.append("t.favorite = 1")
+
+    where_sql = f"WHERE {' AND '.join(where_clauses)}" if where_clauses else ""
 
     db = get_db()
     tickets = db.execute(
@@ -71,11 +109,24 @@ def index() -> str:
                t.shared_with_manager, t.favorite
         FROM tickets t
         JOIN categories c ON t.category_id = c.id
+        {where_sql}
         ORDER BY {sort_column} {sort_order}, t.id DESC
-        """
+        """,
+        params,
     ).fetchall()
 
     categories = db.execute("SELECT id, name FROM categories ORDER BY name ASC").fetchall()
+
+    ticket_to_edit = None
+    if edit_id.isdigit():
+        ticket_to_edit = db.execute(
+            """
+            SELECT id, link, category_id, description, date, shared_with_manager, favorite
+            FROM tickets
+            WHERE id = ?
+            """,
+            (edit_id,),
+        ).fetchone()
 
     return render_template(
         "index.html",
@@ -83,24 +134,17 @@ def index() -> str:
         categories=categories,
         sort_by=sort_by,
         order=order,
+        description_search=description_search,
+        shared_only=shared_only,
+        favorite_only=favorite_only,
+        ticket_to_edit=ticket_to_edit,
     )
 
 
 @app.route("/tickets", methods=["POST"])
 def add_ticket() -> Any:
-    link = request.form.get("link", "").strip()
-    category_id = request.form.get("category_id", "").strip()
-    description = request.form.get("description", "").strip()
-    date_value = request.form.get("date", "").strip()
-    shared_with_manager = 1 if request.form.get("shared_with_manager") == "on" else 0
-    favorite = 1 if request.form.get("favorite") == "on" else 0
-
-    if not link or not category_id or not description or not date_value:
-        return redirect(url_for("index"))
-
-    try:
-        datetime.strptime(date_value, "%Y-%m-%d")
-    except ValueError:
+    ticket_fields = _validated_ticket_fields(request.form)
+    if ticket_fields is None:
         return redirect(url_for("index"))
 
     db = get_db()
@@ -109,7 +153,31 @@ def add_ticket() -> Any:
         INSERT INTO tickets (link, category_id, description, date, shared_with_manager, favorite)
         VALUES (?, ?, ?, ?, ?, ?)
         """,
-        (link, category_id, description, date_value, shared_with_manager, favorite),
+        ticket_fields,
+    )
+    db.commit()
+    return redirect(url_for("index"))
+
+
+@app.route("/tickets/<int:ticket_id>/edit", methods=["POST"])
+def edit_ticket(ticket_id: int) -> Any:
+    ticket_fields = _validated_ticket_fields(request.form)
+    if ticket_fields is None:
+        return redirect(url_for("index", edit_id=ticket_id))
+
+    db = get_db()
+    db.execute(
+        """
+        UPDATE tickets
+        SET link = ?,
+            category_id = ?,
+            description = ?,
+            date = ?,
+            shared_with_manager = ?,
+            favorite = ?
+        WHERE id = ?
+        """,
+        (*ticket_fields, ticket_id),
     )
     db.commit()
     return redirect(url_for("index"))

--- a/templates/index.html
+++ b/templates/index.html
@@ -19,6 +19,10 @@
     th { background: #f0f0f0; }
     .sort-links a { margin-right: 0.6rem; }
     .muted { color: #666; font-size: 0.9rem; }
+    .controls { margin: 1rem 0; }
+    .controls form { display: grid; grid-template-columns: 2fr 1fr 1fr auto; gap: 0.5rem; align-items: center; }
+    .controls label { margin: 0; font-weight: normal; }
+    .actions a { text-decoration: none; }
   </style>
 </head>
 <body>
@@ -66,13 +70,71 @@
     </form>
   </div>
 
+  {% if ticket_to_edit %}
+  <form action="{{ url_for('edit_ticket', ticket_id=ticket_to_edit['id']) }}" method="post">
+    <h2>Edit Ticket #{{ ticket_to_edit['id'] }}</h2>
+    <label for="edit_link">Ticket Link</label>
+    <input id="edit_link" name="link" type="url" value="{{ ticket_to_edit['link'] }}" required />
+
+    <label for="edit_category_id">Category</label>
+    <select id="edit_category_id" name="category_id" required>
+      {% for category in categories %}
+        <option value="{{ category['id'] }}" {% if category['id'] == ticket_to_edit['category_id'] %}selected{% endif %}>
+          {{ category['name'] }}
+        </option>
+      {% endfor %}
+    </select>
+
+    <label for="edit_description">Description</label>
+    <textarea id="edit_description" name="description" required>{{ ticket_to_edit['description'] }}</textarea>
+
+    <label for="edit_date">Date</label>
+    <input id="edit_date" name="date" type="date" value="{{ ticket_to_edit['date'] }}" required />
+
+    <label class="inline" for="edit_shared_with_manager">
+      <input id="edit_shared_with_manager" name="shared_with_manager" type="checkbox" {% if ticket_to_edit['shared_with_manager'] %}checked{% endif %} />
+      Shared with manager
+    </label>
+
+    <label class="inline" for="edit_favorite">
+      <input id="edit_favorite" name="favorite" type="checkbox" {% if ticket_to_edit['favorite'] %}checked{% endif %} />
+      Favorite
+    </label>
+
+    <button type="submit">Update Ticket</button>
+    <p class="muted"><a href="{{ url_for('index') }}">Cancel editing</a></p>
+  </form>
+  {% endif %}
+
   <h2>Saved Tickets</h2>
+
+  <div class="controls">
+    <form method="get" action="{{ url_for('index') }}">
+      <input type="hidden" name="sort_by" value="{{ sort_by }}" />
+      <input type="hidden" name="order" value="{{ order }}" />
+
+      <input name="q" type="text" placeholder="Search description..." value="{{ description_search }}" />
+
+      <label class="inline" for="shared_only">
+        <input id="shared_only" name="shared_only" type="checkbox" value="1" {% if shared_only %}checked{% endif %} />
+        Shared only
+      </label>
+
+      <label class="inline" for="favorite_only">
+        <input id="favorite_only" name="favorite_only" type="checkbox" value="1" {% if favorite_only %}checked{% endif %} />
+        Favorites only
+      </label>
+
+      <button type="submit">Apply</button>
+    </form>
+  </div>
+
   <div class="sort-links">
     Sort by:
-    <a href="{{ url_for('index', sort_by='category', order='asc') }}">Category (A→Z)</a>
-    <a href="{{ url_for('index', sort_by='category', order='desc') }}">Category (Z→A)</a>
-    <a href="{{ url_for('index', sort_by='date', order='asc') }}">Date (Oldest)</a>
-    <a href="{{ url_for('index', sort_by='date', order='desc') }}">Date (Newest)</a>
+    <a href="{{ url_for('index', sort_by='category', order='asc', q=description_search, shared_only=1 if shared_only else 0, favorite_only=1 if favorite_only else 0) }}">Category (A→Z)</a>
+    <a href="{{ url_for('index', sort_by='category', order='desc', q=description_search, shared_only=1 if shared_only else 0, favorite_only=1 if favorite_only else 0) }}">Category (Z→A)</a>
+    <a href="{{ url_for('index', sort_by='date', order='asc', q=description_search, shared_only=1 if shared_only else 0, favorite_only=1 if favorite_only else 0) }}">Date (Oldest)</a>
+    <a href="{{ url_for('index', sort_by='date', order='desc', q=description_search, shared_only=1 if shared_only else 0, favorite_only=1 if favorite_only else 0) }}">Date (Newest)</a>
   </div>
 
   <table>
@@ -84,6 +146,7 @@
         <th>Date</th>
         <th>Shared with Manager</th>
         <th>Favorite</th>
+        <th>Actions</th>
       </tr>
     </thead>
     <tbody>
@@ -95,10 +158,11 @@
         <td>{{ ticket['date'] }}</td>
         <td>{{ '✅' if ticket['shared_with_manager'] else '❌' }}</td>
         <td>{{ '⭐' if ticket['favorite'] else '—' }}</td>
+        <td class="actions"><a href="{{ url_for('index', edit_id=ticket['id'], sort_by=sort_by, order=order, q=description_search, shared_only=1 if shared_only else 0, favorite_only=1 if favorite_only else 0) }}">Edit</a></td>
       </tr>
       {% else %}
       <tr>
-        <td colspan="6">No tickets added yet.</td>
+        <td colspan="7">No tickets matched the current filters.</td>
       </tr>
       {% endfor %}
     </tbody>


### PR DESCRIPTION
### Motivation
- Enable text search over the `description` field so users can find entries by substring.
- Provide quick boolean filters to show only items shared with the manager or only favorites.
- Allow editing of existing ticket entries in-place to correct or update saved data.

### Description
- Add a shared validation helper ` _validated_ticket_fields` to centralize form field and date checks used by create and edit flows in `app.py`.
- Extend the `index` handler to accept `q`, `shared_only`, `favorite_only`, and `edit_id` query params, build a dynamic `WHERE` clause with parameters, and pass filter state into the template.
- Add a POST edit endpoint `POST /tickets/<int:ticket_id>/edit` that updates an existing ticket using the same validation helper.
- Update `templates/index.html` to include a search/filter control panel, an edit form that pre-populates when `edit_id` is set, an "Edit" action per row, and preserve active filters in sort links; update `README.md` feature list accordingly.

### Testing
- Ran static compile check with `python -m py_compile app.py`, which succeeded.
- Attempted to install dependencies with `pip install -r requirements.txt`, which failed due to network/proxy restrictions in the environment so Flask could not be installed.
- Attempted to run the app and exercise a test client flow, but that run failed because Flask was not importable in this environment due to the dependency installation failure.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a775cfe290832bbc9e15b4b6e86644)