### PR TITLE
Add category-specific filter to ticket search

### DIFF
--- a/app.py
+++ b/app.py
@@ -79,6 +79,7 @@ def index() -> str:
     sort_by = request.args.get("sort_by", "date")
     order = request.args.get("order", "desc")
     description_search = request.args.get("q", "").strip()
+    category_filter = request.args.get("category_id", "").strip()
     shared_only = request.args.get("shared_only", "0") == "1"
     favorite_only = request.args.get("favorite_only", "0") == "1"
     edit_id = request.args.get("edit_id", "").strip()
@@ -93,6 +94,10 @@ def index() -> str:
     if description_search:
         where_clauses.append("LOWER(t.description) LIKE ?")
         params.append(f"%{description_search.lower()}%")
+
+    if category_filter.isdigit():
+        where_clauses.append("t.category_id = ?")
+        params.append(int(category_filter))
 
     if shared_only:
         where_clauses.append("t.shared_with_manager = 1")
@@ -135,6 +140,7 @@ def index() -> str:
         sort_by=sort_by,
         order=order,
         description_search=description_search,
+        category_filter=category_filter,
         shared_only=shared_only,
         favorite_only=favorite_only,
         ticket_to_edit=ticket_to_edit,

--- a/templates/index.html
+++ b/templates/index.html
@@ -128,6 +128,15 @@
 
       <input name="q" type="text" placeholder="Search description..." value="{{ description_search }}" />
 
+      <select id="category_id_filter" name="category_id">
+        <option value="">All categories</option>
+        {% for category in categories %}
+          <option value="{{ category['id'] }}" {% if category_filter == category['id']|string %}selected{% endif %}>
+            {{ category['name'] }}
+          </option>
+        {% endfor %}
+      </select>
+
       <label class="inline" for="shared_only">
         <input id="shared_only" name="shared_only" type="checkbox" value="1" {% if shared_only %}checked{% endif %} />
         Shared only
@@ -144,10 +153,10 @@
 
   <div class="sort-links">
     Sort by:
-    <a href="{{ url_for('index', sort_by='category', order='asc', q=description_search, shared_only=1 if shared_only else 0, favorite_only=1 if favorite_only else 0) }}">Category (A→Z)</a>
-    <a href="{{ url_for('index', sort_by='category', order='desc', q=description_search, shared_only=1 if shared_only else 0, favorite_only=1 if favorite_only else 0) }}">Category (Z→A)</a>
-    <a href="{{ url_for('index', sort_by='date', order='asc', q=description_search, shared_only=1 if shared_only else 0, favorite_only=1 if favorite_only else 0) }}">Date (Oldest)</a>
-    <a href="{{ url_for('index', sort_by='date', order='desc', q=description_search, shared_only=1 if shared_only else 0, favorite_only=1 if favorite_only else 0) }}">Date (Newest)</a>
+    <a href="{{ url_for('index', sort_by='category', order='asc', q=description_search, category_id=category_filter, shared_only=1 if shared_only else 0, favorite_only=1 if favorite_only else 0) }}">Category (A→Z)</a>
+    <a href="{{ url_for('index', sort_by='category', order='desc', q=description_search, category_id=category_filter, shared_only=1 if shared_only else 0, favorite_only=1 if favorite_only else 0) }}">Category (Z→A)</a>
+    <a href="{{ url_for('index', sort_by='date', order='asc', q=description_search, category_id=category_filter, shared_only=1 if shared_only else 0, favorite_only=1 if favorite_only else 0) }}">Date (Oldest)</a>
+    <a href="{{ url_for('index', sort_by='date', order='desc', q=description_search, category_id=category_filter, shared_only=1 if shared_only else 0, favorite_only=1 if favorite_only else 0) }}">Date (Newest)</a>
   </div>
 
   <table>
@@ -172,7 +181,7 @@
         <td>{{ '✅' if ticket['shared_with_manager'] else '❌' }}</td>
         <td>{{ '⭐' if ticket['favorite'] else '—' }}</td>
         <td class="actions">
-          <a href="{{ url_for('index', edit_id=ticket['id'], sort_by=sort_by, order=order, q=description_search, shared_only=1 if shared_only else 0, favorite_only=1 if favorite_only else 0) }}">Edit</a>
+          <a href="{{ url_for('index', edit_id=ticket['id'], sort_by=sort_by, order=order, q=description_search, category_id=category_filter, shared_only=1 if shared_only else 0, favorite_only=1 if favorite_only else 0) }}">Edit</a>
           <form action="{{ url_for('delete_ticket', ticket_id=ticket['id']) }}" method="post">
             <button class="danger" type="submit" onclick="return confirm('Delete this ticket?');">Delete</button>
           </form>


### PR DESCRIPTION
### Motivation
- Allow users to narrow the ticket list to a single category from the UI instead of only relying on sorting A→Z or manual searching.
- Preserve the selected category across sorting and edit flows so filtering remains stable while navigating.

### Description
- Added a `category_id` query parameter to the `index` route and applied it as an optional SQL filter when present in `app.py`.
- Passed the selected `category_filter` back into the template context so the UI retains the chosen value after actions in `app.py`.
- Added a category dropdown to the filter controls in `templates/index.html` and included `category_id` in the sort and edit link URLs to preserve the filter across navigation.
- Files modified: `app.py` and `templates/index.html`.

### Testing
- Compiled files with `python -m compileall app.py templates/index.html` and the step completed successfully.
- Launched the Flask app and exercised the UI, capturing a screenshot of the updated filter dropdown with a headless browser run which completed successfully.
- No automated test failures were observed during these validation steps.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a77ccbafc4832b930662f2c8b7aaf7)