### PR TITLE
Add AI Analysis HTML field with modal preview

### DIFF
--- a/app.py
+++ b/app.py
@@ -44,6 +44,7 @@ def init_db() -> None:
             link TEXT NOT NULL,
             category_id INTEGER NOT NULL,
             description TEXT NOT NULL,
+            ai_analysis TEXT NOT NULL DEFAULT '',
             date TEXT NOT NULL,
             shared_with_manager INTEGER NOT NULL DEFAULT 0,
             favorite INTEGER NOT NULL DEFAULT 0,
@@ -51,14 +52,22 @@ def init_db() -> None:
         )
         """
     )
+
+    ticket_columns = {
+        row[1] for row in db.execute("PRAGMA table_info(tickets)").fetchall()
+    }
+    if "ai_analysis" not in ticket_columns:
+        db.execute("ALTER TABLE tickets ADD COLUMN ai_analysis TEXT NOT NULL DEFAULT ''")
+
     db.commit()
     db.close()
 
 
-def _validated_ticket_fields(form: Any) -> tuple[str, str, str, str, int, int] | None:
+def _validated_ticket_fields(form: Any) -> tuple[str, str, str, str, str, int, int] | None:
     link = form.get("link", "").strip()
     category_id = form.get("category_id", "").strip()
     description = form.get("description", "").strip()
+    ai_analysis = form.get("ai_analysis", "")
     date_value = form.get("date", "").strip()
     shared_with_manager = 1 if form.get("shared_with_manager") == "on" else 0
     favorite = 1 if form.get("favorite") == "on" else 0
@@ -71,7 +80,15 @@ def _validated_ticket_fields(form: Any) -> tuple[str, str, str, str, int, int] |
     except ValueError:
         return None
 
-    return link, category_id, description, date_value, shared_with_manager, favorite
+    return (
+        link,
+        category_id,
+        description,
+        ai_analysis,
+        date_value,
+        shared_with_manager,
+        favorite,
+    )
 
 
 @app.route("/", methods=["GET"])
@@ -111,7 +128,7 @@ def index() -> str:
     tickets = db.execute(
         f"""
         SELECT t.id, t.link, c.name AS category, t.description, t.date,
-               t.shared_with_manager, t.favorite
+               t.ai_analysis, t.shared_with_manager, t.favorite
         FROM tickets t
         JOIN categories c ON t.category_id = c.id
         {where_sql}
@@ -126,7 +143,7 @@ def index() -> str:
     if edit_id.isdigit():
         ticket_to_edit = db.execute(
             """
-            SELECT id, link, category_id, description, date, shared_with_manager, favorite
+            SELECT id, link, category_id, description, ai_analysis, date, shared_with_manager, favorite
             FROM tickets
             WHERE id = ?
             """,
@@ -157,8 +174,8 @@ def add_ticket() -> Any:
     db = get_db()
     db.execute(
         """
-        INSERT INTO tickets (link, category_id, description, date, shared_with_manager, favorite)
-        VALUES (?, ?, ?, ?, ?, ?)
+        INSERT INTO tickets (link, category_id, description, ai_analysis, date, shared_with_manager, favorite)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
         """,
         ticket_fields,
     )
@@ -179,6 +196,7 @@ def edit_ticket(ticket_id: int) -> Any:
         SET link = ?,
             category_id = ?,
             description = ?,
+            ai_analysis = ?,
             date = ?,
             shared_with_manager = ?,
             favorite = ?

--- a/templates/index.html
+++ b/templates/index.html
@@ -31,6 +31,13 @@
     .actions a { text-decoration: none; }
     .actions form { border: 0; background: transparent; padding: 0; }
     .actions button { width: auto; padding: 0.25rem 0.5rem; }
+    .analysis-link { color: #1565c0; text-decoration: underline; cursor: pointer; border: 0; background: transparent; padding: 0; font-size: inherit; }
+    .modal.hidden { display: none; }
+    .modal { position: fixed; inset: 0; background: rgba(0, 0, 0, 0.55); display: flex; align-items: center; justify-content: center; padding: 1rem; z-index: 999; }
+    .modal-content { background: #fff; border-radius: 8px; width: min(100%, 1000px); height: min(100%, 750px); display: flex; flex-direction: column; overflow: hidden; }
+    .modal-header { padding: 0.75rem 1rem; border-bottom: 1px solid #ddd; display: flex; justify-content: space-between; align-items: center; }
+    .modal-header button { width: auto; }
+    .modal iframe { border: 0; width: 100%; flex: 1; }
     @media (max-width: 840px) {
       .layout { grid-template-columns: 1fr; }
       .controls form { grid-template-columns: 1fr; }
@@ -56,6 +63,9 @@
 
       <label for="description">Description</label>
       <textarea id="description" name="description" required></textarea>
+
+      <label for="ai_analysis">AI Analysis (HTML)</label>
+      <textarea id="ai_analysis" name="ai_analysis" placeholder="Paste raw HTML for AI analysis"></textarea>
 
       <label for="date">Date</label>
       <input id="date" name="date" type="date" value="{{ today_date }}" required />
@@ -98,6 +108,9 @@
 
     <label for="edit_description">Description</label>
     <textarea id="edit_description" name="description" required>{{ ticket_to_edit['description'] }}</textarea>
+
+    <label for="edit_ai_analysis">AI Analysis (HTML)</label>
+    <textarea id="edit_ai_analysis" name="ai_analysis" placeholder="Paste raw HTML for AI analysis">{{ ticket_to_edit['ai_analysis'] }}</textarea>
 
     <label for="edit_date">Date</label>
     <input id="edit_date" name="date" type="date" value="{{ ticket_to_edit['date'] }}" required />
@@ -166,6 +179,7 @@
         <th>Category</th>
         <th>Description</th>
         <th>Date</th>
+        <th>AI Analysis</th>
         <th>Shared with Manager</th>
         <th>Favorite</th>
         <th>Actions</th>
@@ -178,6 +192,19 @@
         <td>{{ ticket['category'] }}</td>
         <td>{{ ticket['description'] }}</td>
         <td>{{ ticket['date'] }}</td>
+        <td>
+          {% if ticket['ai_analysis'] %}
+            <button
+              type="button"
+              class="analysis-link"
+              data-analysis-html="{{ ticket['ai_analysis']|e }}"
+            >
+              View analysis
+            </button>
+          {% else %}
+            —
+          {% endif %}
+        </td>
         <td>{{ '✅' if ticket['shared_with_manager'] else '❌' }}</td>
         <td>{{ '⭐' if ticket['favorite'] else '—' }}</td>
         <td class="actions">
@@ -189,10 +216,51 @@
       </tr>
       {% else %}
       <tr>
-        <td colspan="7">No tickets matched the current filters.</td>
+        <td colspan="8">No tickets matched the current filters.</td>
       </tr>
       {% endfor %}
     </tbody>
   </table>
+
+  <div id="analysis-modal" class="modal hidden" role="dialog" aria-modal="true" aria-labelledby="analysis-modal-title">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h3 id="analysis-modal-title">AI Analysis</h3>
+        <button id="close-analysis-modal" type="button">Close</button>
+      </div>
+      <iframe id="analysis-frame" title="AI analysis HTML preview"></iframe>
+    </div>
+  </div>
+
+  <script>
+    const analysisModal = document.getElementById('analysis-modal');
+    const analysisFrame = document.getElementById('analysis-frame');
+    const closeAnalysisModalButton = document.getElementById('close-analysis-modal');
+
+    document.querySelectorAll('[data-analysis-html]').forEach((button) => {
+      button.addEventListener('click', () => {
+        analysisFrame.srcdoc = button.dataset.analysisHtml;
+        analysisModal.classList.remove('hidden');
+      });
+    });
+
+    function closeAnalysisModal() {
+      analysisModal.classList.add('hidden');
+      analysisFrame.srcdoc = '';
+    }
+
+    closeAnalysisModalButton.addEventListener('click', closeAnalysisModal);
+    analysisModal.addEventListener('click', (event) => {
+      if (event.target === analysisModal) {
+        closeAnalysisModal();
+      }
+    });
+
+    document.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape' && !analysisModal.classList.contains('hidden')) {
+        closeAnalysisModal();
+      }
+    });
+  </script>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Allow storing raw HTML analysis produced by AI alongside tickets so users can attach rich, pre-rendered analysis to an entry.  
- Provide a safe, discoverable way to preview that HTML from the tickets list without navigating away.  
- Support entering the raw HTML during create/edit flows and preserve it for later review.

### Description
- Added a new `ai_analysis` column to the `tickets` schema with `DEFAULT ''` and a runtime migration that runs `ALTER TABLE` when the column is missing to remain backward-compatible.  
- Wired `ai_analysis` into server validation and persistence by updating `_validated_ticket_fields`, the `INSERT` in `add_ticket`, and the `UPDATE` in `edit_ticket`.  
- Included `ai_analysis` in the ticket `SELECT` queries and the `ticket_to_edit` read so the field is loaded for list and edit views.  
- Updated `templates/index.html` to add `AI Analysis` textarea inputs on create/edit forms, a table column showing a `View analysis` link-style button when HTML exists, and a modal with an iframe that sets `srcdoc` to the stored HTML; added JS for opening/closing and CSS for the modal.

### Testing
- Ran `python -m py_compile app.py` which succeeded with no syntax errors.  
- Launched the Flask app locally and exercised the create/edit flows manually via an automated Playwright script to create a category and ticket containing sample AI HTML, which inserted and loaded correctly.  
- Used Playwright to click the `View analysis` button and captured a screenshot of the modal preview to confirm the iframe `srcdoc` renders the stored HTML (screenshot produced successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a78230b918832b8c84b911aefefac0)