### PR TITLE
Render mixed HTML + Markdown in AI analysis modal

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Ticket Tracker</title>
+  <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
   <style>
     body { font-family: Arial, sans-serif; margin: 2rem; color: #222; }
     h1, h2 { margin-bottom: 0.5rem; }
@@ -237,9 +238,44 @@
     const analysisFrame = document.getElementById('analysis-frame');
     const closeAnalysisModalButton = document.getElementById('close-analysis-modal');
 
+    function renderMixedAnalysis(rawAnalysis) {
+      const raw = (rawAnalysis || '').trim();
+      if (!raw) {
+        return '';
+      }
+
+      const lowerRaw = raw.toLowerCase();
+      const htmlStart = lowerRaw.indexOf('<html');
+      const htmlEnd = lowerRaw.lastIndexOf('</html>');
+
+      if (htmlStart !== -1 && htmlEnd !== -1 && htmlEnd > htmlStart) {
+        const htmlDocument = raw.slice(htmlStart, htmlEnd + 7);
+        const trailingMarkdown = raw.slice(htmlEnd + 7).trim();
+
+        if (!trailingMarkdown) {
+          return htmlDocument;
+        }
+
+        const renderedMarkdown = marked.parse(trailingMarkdown);
+        const markdownSection = `\n<section style="margin: 2rem; padding: 1.25rem; border: 1px solid #ddd; border-radius: 8px; font-family: Arial, sans-serif;">\n<h2 style="margin-top: 0;">Additional AI Notes</h2>\n${renderedMarkdown}\n</section>\n`;
+
+        if (htmlDocument.toLowerCase().includes('</body>')) {
+          return htmlDocument.replace(/<\/body>/i, `${markdownSection}</body>`);
+        }
+
+        return `${htmlDocument}${markdownSection}`;
+      }
+
+      if (raw.includes('<') && raw.includes('>')) {
+        return raw;
+      }
+
+      return `<!doctype html><html><head><meta charset="utf-8" /><title>AI Analysis</title></head><body style="font-family: Arial, sans-serif; padding: 1.25rem;">${marked.parse(raw)}</body></html>`;
+    }
+
     document.querySelectorAll('[data-analysis-html]').forEach((button) => {
       button.addEventListener('click', () => {
-        analysisFrame.srcdoc = button.dataset.analysisHtml;
+        analysisFrame.srcdoc = renderMixedAnalysis(button.dataset.analysisHtml);
         analysisModal.classList.remove('hidden');
       });
     });


### PR DESCRIPTION
### Motivation
- AI analysis content may include a full HTML document plus additional Markdown notes, and the modal should render both parts cleanly.
- The current modal assigned raw `srcdoc` which did not handle trailing Markdown or mixed HTML/Markdown payloads.

### Description
- Added the `marked` client-side renderer via `<script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>` to enable Markdown rendering in the browser.
- Implemented `renderMixedAnalysis(rawAnalysis)` which detects a complete HTML document, preserves and renders that HTML, extracts any trailing Markdown after `</html>` and appends it as an "Additional AI Notes" section, and falls back to rendering Markdown-only content inside a simple HTML wrapper.
- Replaced the modal open handler to set `analysisFrame.srcdoc = renderMixedAnalysis(button.dataset.analysisHtml)` so mixed content displays correctly in the iframe.

### Testing
- Ran `python -m py_compile app.py` which completed successfully. 
- Started the Flask server to validate integration, but automated browser validation using Playwright failed because Chromium crashed in this environment with a SIGSEGV, so no screenshot could be captured.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7939106dc832ba276871056a9e655)