### PR TITLE
Fix markdown rendering under mixed HTML AI analysis

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -248,9 +248,33 @@
       const htmlStart = lowerRaw.indexOf('<html');
       const htmlEnd = lowerRaw.lastIndexOf('</html>');
 
+      function normalizeMarkdown(rawMarkdown) {
+        let normalized = (rawMarkdown || '').trim();
+        if (!normalized) {
+          return '';
+        }
+
+        const fencedBlockMatch = normalized.match(/^```(?:markdown|md)?\s*\n([\s\S]*?)\n```$/i);
+        if (fencedBlockMatch) {
+          normalized = fencedBlockMatch[1].trim();
+        }
+
+        const lines = normalized.split('\n');
+        const indentedLines = lines
+          .filter((line) => line.trim())
+          .map((line) => line.match(/^\s*/)[0].length);
+        const commonIndent = indentedLines.length ? Math.min(...indentedLines) : 0;
+
+        if (commonIndent >= 2) {
+          normalized = lines.map((line) => line.slice(commonIndent)).join('\n');
+        }
+
+        return normalized;
+      }
+
       if (htmlStart !== -1 && htmlEnd !== -1 && htmlEnd > htmlStart) {
         const htmlDocument = raw.slice(htmlStart, htmlEnd + 7);
-        const trailingMarkdown = raw.slice(htmlEnd + 7).trim();
+        const trailingMarkdown = normalizeMarkdown(raw.slice(htmlEnd + 7));
 
         if (!trailingMarkdown) {
           return htmlDocument;
@@ -270,7 +294,7 @@
         return raw;
       }
 
-      return `<!doctype html><html><head><meta charset="utf-8" /><title>AI Analysis</title></head><body style="font-family: Arial, sans-serif; padding: 1.25rem;">${marked.parse(raw)}</body></html>`;
+      return `<!doctype html><html><head><meta charset="utf-8" /><title>AI Analysis</title></head><body style="font-family: Arial, sans-serif; padding: 1.25rem;">${marked.parse(normalizeMarkdown(raw))}</body></html>`;
     }
 
     document.querySelectorAll('[data-analysis-html]').forEach((button) => {


### PR DESCRIPTION
### Motivation
- Trailing markdown provided after an embedded HTML analysis was sometimes rendered verbatim (as code or raw text) when it was wrapped in fenced blocks or had leading indentation, preventing expected Markdown-to-HTML rendering.

### Description
- Added a `normalizeMarkdown` helper inside `renderMixedAnalysis` in `templates/index.html` that unwraps fenced blocks (e.g. ```markdown ... ```), trims, and removes common leading indentation. 
- Applied `normalizeMarkdown` to the markdown extracted after a full HTML document and to markdown-only analysis payloads before calling `marked.parse`.
- Ensured the existing modal/iframe rendering flow remains unchanged while the appended “Additional AI Notes” are now parsed as real HTML markup instead of literal markdown punctuation.

### Testing
- Launched the app with `python app.py` and confirmed the server started successfully. (succeeded)
- Ran a Playwright evaluation that invoked `renderMixedAnalysis` with a sample containing a full HTML fragment followed by a fenced markdown block; the result showed the heading rendered as HTML (`hasHeading=True`) and no `pre/code` fence was produced (`hasCodeFence=False`). (succeeded)
- An initial end-to-end Playwright run timed out at 30s, but a focused evaluation and additional UI screenshot capture of the analysis modal completed successfully. (one timeout then successful validation)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7953b7c98832b851ccf28d0aa1352)