### PR TITLE
Add tags support, enlarge AI analysis view, and remove sort links

### DIFF
--- a/app.py
+++ b/app.py
@@ -52,6 +52,25 @@ def init_db() -> None:
         )
         """
     )
+    db.execute(
+        """
+        CREATE TABLE IF NOT EXISTS tags (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT UNIQUE NOT NULL COLLATE NOCASE
+        )
+        """
+    )
+    db.execute(
+        """
+        CREATE TABLE IF NOT EXISTS ticket_tags (
+            ticket_id INTEGER NOT NULL,
+            tag_id INTEGER NOT NULL,
+            PRIMARY KEY (ticket_id, tag_id),
+            FOREIGN KEY (ticket_id) REFERENCES tickets (id) ON DELETE CASCADE,
+            FOREIGN KEY (tag_id) REFERENCES tags (id) ON DELETE CASCADE
+        )
+        """
+    )
 
     ticket_columns = {
         row[1] for row in db.execute("PRAGMA table_info(tickets)").fetchall()
@@ -63,7 +82,38 @@ def init_db() -> None:
     db.close()
 
 
-def _validated_ticket_fields(form: Any) -> tuple[str, str, str, str, str, int, int] | None:
+def _parse_tags(raw_tags: str) -> list[str]:
+    tag_names: list[str] = []
+    seen: set[str] = set()
+
+    for part in raw_tags.split(","):
+        tag = part.strip()
+        if not tag:
+            continue
+        lowered_tag = tag.lower()
+        if lowered_tag in seen:
+            continue
+        seen.add(lowered_tag)
+        tag_names.append(tag)
+
+    return tag_names
+
+
+def _sync_ticket_tags(db: sqlite3.Connection, ticket_id: int, tag_names: list[str]) -> None:
+    db.execute("DELETE FROM ticket_tags WHERE ticket_id = ?", (ticket_id,))
+
+    for tag_name in tag_names:
+        db.execute("INSERT OR IGNORE INTO tags (name) VALUES (?)", (tag_name,))
+        tag_id_row = db.execute("SELECT id FROM tags WHERE LOWER(name) = LOWER(?)", (tag_name,)).fetchone()
+        if tag_id_row is None:
+            continue
+        db.execute(
+            "INSERT OR IGNORE INTO ticket_tags (ticket_id, tag_id) VALUES (?, ?)",
+            (ticket_id, tag_id_row["id"]),
+        )
+
+
+def _validated_ticket_fields(form: Any) -> tuple[str, str, str, str, str, int, int, list[str]] | None:
     link = form.get("link", "").strip()
     category_id = form.get("category_id", "").strip()
     description = form.get("description", "").strip()
@@ -71,6 +121,7 @@ def _validated_ticket_fields(form: Any) -> tuple[str, str, str, str, str, int, i
     date_value = form.get("date", "").strip()
     shared_with_manager = 1 if form.get("shared_with_manager") == "on" else 0
     favorite = 1 if form.get("favorite") == "on" else 0
+    tags = _parse_tags(form.get("tags", ""))
 
     if not link or not category_id or not description or not date_value:
         return None
@@ -88,6 +139,7 @@ def _validated_ticket_fields(form: Any) -> tuple[str, str, str, str, str, int, i
         date_value,
         shared_with_manager,
         favorite,
+        tags,
     )
 
 
@@ -99,6 +151,7 @@ def index() -> str:
     category_filter = request.args.get("category_id", "").strip()
     shared_only = request.args.get("shared_only", "0") == "1"
     favorite_only = request.args.get("favorite_only", "0") == "1"
+    tag_filter = request.args.get("tags", "").strip()
     edit_id = request.args.get("edit_id", "").strip()
 
     allowed_sort = {"date": "t.date", "category": "c.name"}
@@ -122,16 +175,34 @@ def index() -> str:
     if favorite_only:
         where_clauses.append("t.favorite = 1")
 
+    for tag in _parse_tags(tag_filter):
+        where_clauses.append(
+            """
+            EXISTS (
+                SELECT 1
+                FROM ticket_tags tt_filter
+                JOIN tags tg_filter ON tg_filter.id = tt_filter.tag_id
+                WHERE tt_filter.ticket_id = t.id
+                  AND LOWER(tg_filter.name) = LOWER(?)
+            )
+            """
+        )
+        params.append(tag)
+
     where_sql = f"WHERE {' AND '.join(where_clauses)}" if where_clauses else ""
 
     db = get_db()
     tickets = db.execute(
         f"""
         SELECT t.id, t.link, c.name AS category, t.description, t.date,
-               t.ai_analysis, t.shared_with_manager, t.favorite
+               t.ai_analysis, t.shared_with_manager, t.favorite,
+               COALESCE(GROUP_CONCAT(tg.name, ', '), '') AS tags
         FROM tickets t
         JOIN categories c ON t.category_id = c.id
+        LEFT JOIN ticket_tags tt ON tt.ticket_id = t.id
+        LEFT JOIN tags tg ON tg.id = tt.tag_id
         {where_sql}
+        GROUP BY t.id
         ORDER BY {sort_column} {sort_order}, t.id DESC
         """,
         params,
@@ -149,6 +220,19 @@ def index() -> str:
             """,
             (edit_id,),
         ).fetchone()
+        if ticket_to_edit is not None:
+            ticket_tags = db.execute(
+                """
+                SELECT tg.name
+                FROM tags tg
+                JOIN ticket_tags tt ON tt.tag_id = tg.id
+                WHERE tt.ticket_id = ?
+                ORDER BY tg.name ASC
+                """,
+                (ticket_to_edit["id"],),
+            ).fetchall()
+            ticket_to_edit = dict(ticket_to_edit)
+            ticket_to_edit["tags"] = ", ".join(tag["name"] for tag in ticket_tags)
 
     return render_template(
         "index.html",
@@ -160,6 +244,7 @@ def index() -> str:
         category_filter=category_filter,
         shared_only=shared_only,
         favorite_only=favorite_only,
+        tag_filter=tag_filter,
         ticket_to_edit=ticket_to_edit,
         today_date=date.today().isoformat(),
     )
@@ -171,14 +256,17 @@ def add_ticket() -> Any:
     if ticket_fields is None:
         return redirect(url_for("index"))
 
+    link, category_id, description, ai_analysis, date_value, shared_with_manager, favorite, tags = ticket_fields
+
     db = get_db()
-    db.execute(
+    cursor = db.execute(
         """
         INSERT INTO tickets (link, category_id, description, ai_analysis, date, shared_with_manager, favorite)
         VALUES (?, ?, ?, ?, ?, ?, ?)
         """,
-        ticket_fields,
+        (link, category_id, description, ai_analysis, date_value, shared_with_manager, favorite),
     )
+    _sync_ticket_tags(db, cursor.lastrowid, tags)
     db.commit()
     return redirect(url_for("index"))
 
@@ -188,6 +276,8 @@ def edit_ticket(ticket_id: int) -> Any:
     ticket_fields = _validated_ticket_fields(request.form)
     if ticket_fields is None:
         return redirect(url_for("index", edit_id=ticket_id))
+
+    link, category_id, description, ai_analysis, date_value, shared_with_manager, favorite, tags = ticket_fields
 
     db = get_db()
     db.execute(
@@ -202,8 +292,9 @@ def edit_ticket(ticket_id: int) -> Any:
             favorite = ?
         WHERE id = ?
         """,
-        (*ticket_fields, ticket_id),
+        (link, category_id, description, ai_analysis, date_value, shared_with_manager, favorite, ticket_id),
     )
+    _sync_ticket_tags(db, ticket_id, tags)
     db.commit()
     return redirect(url_for("index"))
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -15,6 +15,7 @@
     label { display: block; margin: 0.6rem 0 0.25rem; font-weight: bold; }
     input, select, textarea, button { width: 100%; padding: 0.5rem; box-sizing: border-box; }
     textarea { min-height: 80px; }
+    .analysis-input { min-height: 180px; }
     .inline { display: flex; align-items: center; gap: 0.5rem; margin: 0.5rem 0; }
     .inline input { width: auto; }
     .btn-row { display: flex; gap: 0.5rem; }
@@ -26,7 +27,7 @@
     .sort-links a { margin-right: 0.6rem; }
     .muted { color: #666; font-size: 0.9rem; }
     .controls { margin: 1rem 0; }
-    .controls form { display: grid; grid-template-columns: 2fr 1fr 1fr auto; gap: 0.5rem; align-items: center; }
+    .controls form { display: grid; grid-template-columns: 2fr 1fr 1fr 1fr auto; gap: 0.5rem; align-items: center; }
     .controls label { margin: 0; font-weight: normal; }
     .actions { display: flex; gap: 0.5rem; align-items: center; }
     .actions a { text-decoration: none; }
@@ -35,7 +36,7 @@
     .analysis-link { color: #1565c0; text-decoration: underline; cursor: pointer; border: 0; background: transparent; padding: 0; font-size: inherit; }
     .modal.hidden { display: none; }
     .modal { position: fixed; inset: 0; background: rgba(0, 0, 0, 0.55); display: flex; align-items: center; justify-content: center; padding: 1rem; z-index: 999; }
-    .modal-content { background: #fff; border-radius: 8px; width: min(100%, 1000px); height: min(100%, 750px); display: flex; flex-direction: column; overflow: hidden; }
+    .modal-content { background: #fff; border-radius: 8px; width: min(100%, 1200px); height: min(100%, 850px); display: flex; flex-direction: column; overflow: hidden; }
     .modal-header { padding: 0.75rem 1rem; border-bottom: 1px solid #ddd; display: flex; justify-content: space-between; align-items: center; }
     .modal-header button { width: auto; }
     .modal iframe { border: 0; width: 100%; flex: 1; }
@@ -66,7 +67,10 @@
       <textarea id="description" name="description" required></textarea>
 
       <label for="ai_analysis">AI Analysis (HTML)</label>
-      <textarea id="ai_analysis" name="ai_analysis" placeholder="Paste raw HTML for AI analysis"></textarea>
+      <textarea id="ai_analysis" class="analysis-input" name="ai_analysis" placeholder="Paste raw HTML for AI analysis"></textarea>
+
+      <label for="tags">Tags</label>
+      <input id="tags" name="tags" type="text" placeholder="e.g. urgent, follow-up, customer" />
 
       <label for="date">Date</label>
       <input id="date" name="date" type="date" value="{{ today_date }}" required />
@@ -111,7 +115,10 @@
     <textarea id="edit_description" name="description" required>{{ ticket_to_edit['description'] }}</textarea>
 
     <label for="edit_ai_analysis">AI Analysis (HTML)</label>
-    <textarea id="edit_ai_analysis" name="ai_analysis" placeholder="Paste raw HTML for AI analysis">{{ ticket_to_edit['ai_analysis'] }}</textarea>
+    <textarea id="edit_ai_analysis" class="analysis-input" name="ai_analysis" placeholder="Paste raw HTML for AI analysis">{{ ticket_to_edit['ai_analysis'] }}</textarea>
+
+    <label for="edit_tags">Tags</label>
+    <input id="edit_tags" name="tags" type="text" value="{{ ticket_to_edit['tags'] if ticket_to_edit else '' }}" placeholder="e.g. urgent, follow-up, customer" />
 
     <label for="edit_date">Date</label>
     <input id="edit_date" name="date" type="date" value="{{ ticket_to_edit['date'] }}" required />
@@ -137,9 +144,6 @@
 
   <div class="controls">
     <form method="get" action="{{ url_for('index') }}">
-      <input type="hidden" name="sort_by" value="{{ sort_by }}" />
-      <input type="hidden" name="order" value="{{ order }}" />
-
       <input name="q" type="text" placeholder="Search description..." value="{{ description_search }}" />
 
       <select id="category_id_filter" name="category_id">
@@ -161,16 +165,10 @@
         Favorites only
       </label>
 
+      <input name="tags" type="text" placeholder="Filter by tags (comma separated)" value="{{ tag_filter }}" />
+
       <button type="submit">Apply</button>
     </form>
-  </div>
-
-  <div class="sort-links">
-    Sort by:
-    <a href="{{ url_for('index', sort_by='category', order='asc', q=description_search, category_id=category_filter, shared_only=1 if shared_only else 0, favorite_only=1 if favorite_only else 0) }}">Category (A→Z)</a>
-    <a href="{{ url_for('index', sort_by='category', order='desc', q=description_search, category_id=category_filter, shared_only=1 if shared_only else 0, favorite_only=1 if favorite_only else 0) }}">Category (Z→A)</a>
-    <a href="{{ url_for('index', sort_by='date', order='asc', q=description_search, category_id=category_filter, shared_only=1 if shared_only else 0, favorite_only=1 if favorite_only else 0) }}">Date (Oldest)</a>
-    <a href="{{ url_for('index', sort_by='date', order='desc', q=description_search, category_id=category_filter, shared_only=1 if shared_only else 0, favorite_only=1 if favorite_only else 0) }}">Date (Newest)</a>
   </div>
 
   <table>
@@ -181,6 +179,7 @@
         <th>Description</th>
         <th>Date</th>
         <th>AI Analysis</th>
+        <th>Tags</th>
         <th>Shared with Manager</th>
         <th>Favorite</th>
         <th>Actions</th>
@@ -206,10 +205,11 @@
             —
           {% endif %}
         </td>
+        <td>{{ ticket['tags'] if ticket['tags'] else '—' }}</td>
         <td>{{ '✅' if ticket['shared_with_manager'] else '❌' }}</td>
         <td>{{ '⭐' if ticket['favorite'] else '—' }}</td>
         <td class="actions">
-          <a href="{{ url_for('index', edit_id=ticket['id'], sort_by=sort_by, order=order, q=description_search, category_id=category_filter, shared_only=1 if shared_only else 0, favorite_only=1 if favorite_only else 0) }}">Edit</a>
+          <a href="{{ url_for('index', edit_id=ticket['id'], sort_by=sort_by, order=order, q=description_search, category_id=category_filter, shared_only=1 if shared_only else 0, favorite_only=1 if favorite_only else 0, tags=tag_filter) }}">Edit</a>
           <form action="{{ url_for('delete_ticket', ticket_id=ticket['id']) }}" method="post">
             <button class="danger" type="submit" onclick="return confirm('Delete this ticket?');">Delete</button>
           </form>
@@ -217,7 +217,7 @@
       </tr>
       {% else %}
       <tr>
-        <td colspan="8">No tickets matched the current filters.</td>
+        <td colspan="9">No tickets matched the current filters.</td>
       </tr>
       {% endfor %}
     </tbody>


### PR DESCRIPTION
### Motivation
- Provide first-class tagging for tickets so entries can have multiple tags and tags can be created on-the-fly. 
- Make the AI analysis viewer/input larger so analysis content is easier to read. 
- Simplify the UI by removing the static "Sort by" links and add tag-based filtering in the controls.

### Description
- Database and backend: added `tags` and `ticket_tags` tables in `init_db`, plus `_parse_tags` (comma-split + case-insensitive dedupe) and `_sync_ticket_tags` helpers in `app.py` to create/assign tags automatically.
- Ticket lifecycle: extended `_validated_ticket_fields` to accept `tags`, and updated `add_ticket` and `edit_ticket` to persist tag assignments.
- Listing & filtering: `index` now accepts `tags` filter, adds per-tag `EXISTS` clauses to the query, and aggregates tags with `GROUP_CONCAT` so each ticket row includes a `tags` field returned to the template.
- UI changes (`templates/index.html`): increased AI analysis textarea and modal sizes, added `Tags` inputs to add/edit forms, added a tag filter input in the controls, displayed tags in the tickets table, and removed the "Sort by: ..." links.

### Testing
- Ran `python -m py_compile app.py` and it completed successfully.
- Executed a Flask test-client smoke test that creates a ticket with duplicate tags (`urgent, qa, urgent`), verifies tags are deduped/displayed, and confirms tag filtering returns expected results; the test passed.
- Started the app and captured a UI screenshot via Playwright to validate layout changes and increased AI analysis/modal sizing; the capture completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a872bc18c8832bba28a1a1fed76703)