### PR TITLE
Fix tag editor Tab key behavior to avoid skipping to date field

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -452,7 +452,9 @@
 
       tagInput.addEventListener('keydown', (event) => {
         if (event.key === 'Tab') {
+          event.preventDefault();
           commitInputTag();
+          tagInput.focus();
         }
       });
 


### PR DESCRIPTION
### Motivation
- Pressing Tab while entering tags caused the browser to move focus to the next form control (the `date` field) instead of committing the typed tag, disrupting rapid multi-tag entry.

### Description
- Updated `templates/index.html` to prevent default Tab navigation in the tag input, call `commitInputTag()`, and then call `tagInput.focus()` so the tag input remains focused after committing the tag.

### Testing
- Ran `python -m py_compile app.py` which succeeded and executed an automated Playwright script that filled the tag input, sent `Tab`, and produced the screenshot `artifacts/tag-editor-tab-fix.png` showing the tag was committed and focus remained in the tag input.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a87738d38c832b85058e83fae13e96)