### PR TITLE
Add bookmarklet-powered quick ticket entry flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,17 @@ python app.py
 ```
 
 Then open http://127.0.0.1:5000
+
+## Bookmarklet helper
+
+This project includes `static/bookmarklet.js`, which opens a quick-add form and auto-fills the current page URL as the ticket link.
+
+1. Make sure this app is running.
+2. Create a browser bookmark with this URL (single line):
+
+```text
+javascript:(function(){var s=document.createElement('script');s.src='http://127.0.0.1:5000/static/bookmarklet.js';document.body.appendChild(s);}());
+```
+
+3. While viewing a ticket page, click the bookmark.
+4. Fill in description/category/etc. in the popup form and submit. It saves directly into the database.

--- a/app.py
+++ b/app.py
@@ -381,6 +381,83 @@ def add_ticket() -> Any:
     return redirect(url_for("index"))
 
 
+@app.route("/bookmarklet/new", methods=["GET", "POST"])
+def bookmarklet_add_ticket() -> str:
+    db = get_db()
+    categories = db.execute("SELECT id, name FROM categories ORDER BY name ASC").fetchall()
+
+    if request.method == "GET":
+        link = request.args.get("link", "").strip()
+        return render_template(
+            "bookmarklet_form.html",
+            categories=categories,
+            today_date=date.today().isoformat(),
+            success=False,
+            error=False,
+            form_values={
+                "link": link,
+                "description": "",
+                "ai_analysis": "",
+                "tags": "",
+                "date": date.today().isoformat(),
+                "category_id": "",
+                "shared_with_manager": False,
+                "favorite": False,
+            },
+        )
+
+    ticket_fields = _validated_ticket_fields(request.form)
+    form_values = {
+        "link": request.form.get("link", "").strip(),
+        "description": request.form.get("description", "").strip(),
+        "ai_analysis": request.form.get("ai_analysis", ""),
+        "tags": request.form.get("tags", ""),
+        "date": request.form.get("date", "").strip(),
+        "category_id": request.form.get("category_id", "").strip(),
+        "shared_with_manager": request.form.get("shared_with_manager") == "on",
+        "favorite": request.form.get("favorite") == "on",
+    }
+
+    if ticket_fields is None:
+        return render_template(
+            "bookmarklet_form.html",
+            categories=categories,
+            today_date=date.today().isoformat(),
+            success=False,
+            error=True,
+            form_values=form_values,
+        )
+
+    link, category_id, description, ai_analysis, date_value, shared_with_manager, favorite, tags = ticket_fields
+    cursor = db.execute(
+        """
+        INSERT INTO tickets (link, category_id, description, ai_analysis, date, shared_with_manager, favorite)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+        """,
+        (link, category_id, description, ai_analysis, date_value, shared_with_manager, favorite),
+    )
+    _sync_ticket_tags(db, cursor.lastrowid, tags)
+    db.commit()
+
+    form_values.update(
+        {
+            "description": "",
+            "ai_analysis": "",
+            "tags": "",
+            "shared_with_manager": False,
+            "favorite": False,
+        }
+    )
+    return render_template(
+        "bookmarklet_form.html",
+        categories=categories,
+        today_date=date.today().isoformat(),
+        success=True,
+        error=False,
+        form_values=form_values,
+    )
+
+
 @app.route("/tickets/<int:ticket_id>/edit", methods=["POST"])
 def edit_ticket(ticket_id: int) -> Any:
     ticket_fields = _validated_ticket_fields(request.form)

--- a/static/bookmarklet.js
+++ b/static/bookmarklet.js
@@ -1,0 +1,19 @@
+(function () {
+  const configuredBaseUrl = window.PACKCHECKIN_BASE_URL || "http://127.0.0.1:5000";
+
+  let targetUrl;
+  try {
+    targetUrl = new URL("/bookmarklet/new", configuredBaseUrl);
+  } catch (error) {
+    alert("Packcheckin bookmarklet is misconfigured. Set a valid PACKCHECKIN_BASE_URL.");
+    return;
+  }
+
+  targetUrl.searchParams.set("link", window.location.href);
+
+  const popup = window.open(targetUrl.toString(), "packcheckin-bookmarklet", "width=900,height=820,resizable=yes,scrollbars=yes");
+
+  if (!popup) {
+    window.location.href = targetUrl.toString();
+  }
+})();

--- a/templates/bookmarklet_form.html
+++ b/templates/bookmarklet_form.html
@@ -1,0 +1,117 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Quick Add Ticket</title>
+  <style>
+    body {
+      font-family: Arial, sans-serif;
+      max-width: 720px;
+      margin: 2rem auto;
+      padding: 0 1rem;
+      line-height: 1.4;
+    }
+
+    form {
+      display: grid;
+      gap: 0.75rem;
+      border: 1px solid #ddd;
+      border-radius: 8px;
+      padding: 1rem;
+      background: #fafafa;
+    }
+
+    label {
+      font-weight: 600;
+    }
+
+    input,
+    select,
+    textarea,
+    button {
+      font: inherit;
+      padding: 0.5rem;
+    }
+
+    textarea {
+      min-height: 5rem;
+      resize: vertical;
+    }
+
+    .inline {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      font-weight: 400;
+    }
+
+    .message {
+      padding: 0.75rem;
+      border-radius: 6px;
+      margin-bottom: 1rem;
+    }
+
+    .success {
+      background: #e7f8ec;
+      border: 1px solid #70bd84;
+    }
+
+    .error {
+      background: #fdecea;
+      border: 1px solid #da7b73;
+    }
+  </style>
+</head>
+<body>
+  <h1>Quick Add Ticket</h1>
+  <p>This form is intended for bookmarklet usage. It pre-fills the current page URL as the ticket link.</p>
+
+  {% if success %}
+    <div class="message success">Ticket saved successfully.</div>
+  {% endif %}
+
+  {% if error %}
+    <div class="message error">Please fill all required fields with valid values.</div>
+  {% endif %}
+
+  <form method="post" action="{{ url_for('bookmarklet_add_ticket') }}">
+    <label for="link">Ticket Link</label>
+    <input id="link" name="link" type="url" value="{{ form_values['link'] }}" required />
+
+    <label for="category_id">Category</label>
+    <select id="category_id" name="category_id" required>
+      <option value="">Select category</option>
+      {% for category in categories %}
+        <option value="{{ category['id'] }}" {% if form_values['category_id'] == category['id']|string %}selected{% endif %}>
+          {{ category['name'] }}
+        </option>
+      {% endfor %}
+    </select>
+
+    <label for="description">Description</label>
+    <textarea id="description" name="description" required>{{ form_values['description'] }}</textarea>
+
+    <label for="ai_analysis">AI Analysis (optional HTML)</label>
+    <textarea id="ai_analysis" name="ai_analysis">{{ form_values['ai_analysis'] }}</textarea>
+
+    <label for="tags">Tags (comma separated)</label>
+    <input id="tags" name="tags" type="text" value="{{ form_values['tags'] }}" />
+
+    <label for="date">Date</label>
+    <input id="date" name="date" type="date" value="{{ form_values['date'] or today_date }}" required />
+
+    <label class="inline" for="shared_with_manager">
+      <input id="shared_with_manager" name="shared_with_manager" type="checkbox" {% if form_values['shared_with_manager'] %}checked{% endif %} />
+      Shared with manager
+    </label>
+
+    <label class="inline" for="favorite">
+      <input id="favorite" name="favorite" type="checkbox" {% if form_values['favorite'] %}checked{% endif %} />
+      Favorite
+    </label>
+
+    <button type="submit">Save Ticket</button>
+  </form>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Provide a lightweight way to capture the current page URL as a ticket link and quickly create entries without navigating the main app UI.
- Make it easy to open a small popup form from any page using a browser bookmarklet so users can fill description and metadata before saving.

### Description
- Add a new endpoint `GET/POST /bookmarklet/new` that renders a minimal standalone form and accepts ticket submissions, validates fields, inserts into the `tickets` table, and syncs tags (`app.py`).
- Add `templates/bookmarklet_form.html`, a compact quick-add page with required fields (`link`, `category`, `description`, `date`) plus optional `ai_analysis`, `tags`, and flags with success/error messaging.
- Add `static/bookmarklet.js` which captures `window.location.href`, opens `/bookmarklet/new?link=...` in a popup (with fallback to same-tab navigation), and supports a configurable base URL via `PACKCHECKIN_BASE_URL`.
- Document bookmarklet installation and usage in `README.md` with an example `javascript:` bookmark that loads `static/bookmarklet.js`.

### Testing
- `python -m py_compile app.py` succeeded and reported no syntax errors.
- Flask test client request to `GET /bookmarklet/new?link=https://example.com/ticket/123` returned `200` and the response contained the quick-add form title, indicating the template renders correctly.
- End-to-end UI render was exercised by launching the app and capturing a screenshot of the quick-add page via a Playwright script, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a89cfce4e8832ba6dad6180b7051c9)