### PR TITLE
Style 'View ticket'/'View analysis' as buttons and add tag editor to bookmarklet form

### DIFF
--- a/templates/bookmarklet_form.html
+++ b/templates/bookmarklet_form.html
@@ -39,6 +39,47 @@
       resize: vertical;
     }
 
+    .tag-editor {
+      border: 1px solid #ccc;
+      border-radius: 6px;
+      background: #fff;
+      padding: 0.35rem;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.35rem;
+      min-height: 42px;
+    }
+
+    .tag-editor input {
+      border: 0;
+      outline: none;
+      min-width: 180px;
+      flex: 1;
+      padding: 0.35rem;
+    }
+
+    .tag-bubble {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.4rem;
+      background: #e8f0fe;
+      color: #113a8f;
+      border-radius: 999px;
+      padding: 0.2rem 0.55rem;
+      font-size: 0.9rem;
+    }
+
+    .tag-bubble button {
+      width: auto;
+      border: 0;
+      background: transparent;
+      color: inherit;
+      cursor: pointer;
+      padding: 0;
+      line-height: 1;
+      font-size: 1rem;
+    }
+
     .inline {
       display: flex;
       align-items: center;
@@ -95,8 +136,11 @@
     <label for="ai_analysis">AI Analysis (optional HTML)</label>
     <textarea id="ai_analysis" name="ai_analysis">{{ form_values['ai_analysis'] }}</textarea>
 
-    <label for="tags">Tags (comma separated)</label>
-    <input id="tags" name="tags" type="text" value="{{ form_values['tags'] }}" />
+    <label for="tags">Tags</label>
+    <input id="tags" name="tags" type="hidden" value="{{ form_values['tags'] }}" />
+    <div class="tag-editor" data-tag-editor data-hidden-input-id="tags">
+      <input type="text" placeholder="Add a tag then press Tab or click away" data-tag-input />
+    </div>
 
     <label for="date">Date</label>
     <input id="date" name="date" type="date" value="{{ form_values['date'] or today_date }}" required />
@@ -113,5 +157,95 @@
 
     <button type="submit">Save Ticket</button>
   </form>
+
+  <script>
+    function initializeTagEditor(editor) {
+      const hiddenInput = document.getElementById(editor.dataset.hiddenInputId);
+      const tagInput = editor.querySelector('[data-tag-input]');
+      if (!hiddenInput || !tagInput) {
+        return;
+      }
+
+      const tags = [];
+      const existingTags = (hiddenInput.value || '')
+        .split(',')
+        .map((tag) => tag.trim())
+        .filter((tag) => tag);
+
+      function syncHiddenInput() {
+        hiddenInput.value = tags.join(', ');
+      }
+
+      function removeTag(indexToRemove) {
+        tags.splice(indexToRemove, 1);
+        renderTags();
+      }
+
+      function renderTags() {
+        editor.querySelectorAll('.tag-bubble').forEach((bubble) => bubble.remove());
+
+        tags.forEach((tag, index) => {
+          const bubble = document.createElement('span');
+          bubble.className = 'tag-bubble';
+          bubble.textContent = tag;
+
+          const removeButton = document.createElement('button');
+          removeButton.type = 'button';
+          removeButton.setAttribute('aria-label', `Remove ${tag}`);
+          removeButton.textContent = '×';
+          removeButton.addEventListener('click', () => removeTag(index));
+          bubble.appendChild(removeButton);
+
+          editor.insertBefore(bubble, tagInput);
+        });
+
+        syncHiddenInput();
+      }
+
+      function addTag(rawTag) {
+        const tag = (rawTag || '').trim();
+        if (!tag) {
+          return;
+        }
+
+        const lowerTag = tag.toLowerCase();
+        if (tags.some((existingTag) => existingTag.toLowerCase() === lowerTag)) {
+          return;
+        }
+
+        tags.push(tag);
+        renderTags();
+      }
+
+      function commitInputTag() {
+        addTag(tagInput.value);
+        tagInput.value = '';
+      }
+
+      existingTags.forEach((tag) => addTag(tag));
+
+      tagInput.addEventListener('keydown', (event) => {
+        if (event.key === 'Tab') {
+          event.preventDefault();
+          commitInputTag();
+          tagInput.focus();
+        }
+      });
+
+      tagInput.addEventListener('blur', () => {
+        commitInputTag();
+      });
+
+      editor.addEventListener('click', () => {
+        tagInput.focus();
+      });
+
+      renderTags();
+    }
+
+    document.querySelectorAll('[data-tag-editor]').forEach((editor) => {
+      initializeTagEditor(editor);
+    });
+  </script>
 </body>
 </html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -70,7 +70,6 @@
       transition: transform 0.15s ease-in-out;
     }
     .add-ticket-panel[open] summary::after { transform: rotate(90deg); }
-    .analysis-link { color: #1565c0; text-decoration: underline; cursor: pointer; border: 0; background: transparent; padding: 0; font-size: inherit; }
     .modal.hidden { display: none; }
     .modal { position: fixed; inset: 0; background: rgba(0, 0, 0, 0.55); display: flex; align-items: center; justify-content: center; padding: 1rem; z-index: 999; }
     .modal-content { background: #fff; border-radius: 8px; width: min(98vw, 1500px); height: min(95vh, 1050px); display: flex; flex-direction: column; overflow: hidden; }
@@ -240,7 +239,9 @@
     <tbody>
       {% for ticket in tickets %}
       <tr>
-        <td><a href="{{ ticket['link'] }}" target="_blank" rel="noopener">Open Ticket</a></td>
+        <td>
+          <a class="btn secondary" href="{{ ticket['link'] }}" target="_blank" rel="noopener">View ticket</a>
+        </td>
         <td>{{ ticket['category'] }}</td>
         <td>{{ ticket['description'] }}</td>
         <td>{{ ticket['date'] }}</td>
@@ -248,7 +249,7 @@
           {% if ticket['ai_analysis'] %}
             <button
               type="button"
-              class="analysis-link"
+              class="btn secondary"
               data-analysis-html="{{ ticket['ai_analysis']|e }}"
             >
               View analysis


### PR DESCRIPTION
### Motivation
- Make the ticket list actions visually consistent by turning the ticket link and analysis action into styled buttons matching the app's `.btn.secondary` controls.
- Equip the bookmarklet quick-add form with the same tag-editor UX as the main form so users can add tags interactively (commit with `Tab` and on blur).

### Description
- Updated `templates/index.html` to render the ticket URL action as a `.btn.secondary` button labeled `View ticket` and to render the `View analysis` control using the same `.btn.secondary` styling instead of the old `analysis-link` style.
- Removed the separate `analysis-link` visual path in favor of the shared button style for consistent UI appearance.
- Enhanced `templates/bookmarklet_form.html` by adding tag-editor CSS, replacing the simple tags text input with a hidden serialized `tags` input plus a `.tag-editor` element, and adding `initializeTagEditor` JavaScript that supports tag bubbles, tag removal, duplicate prevention (case-insensitive), `Tab`-to-commit and blur-to-commit behavior, and synchronization into the hidden input.
- Minor markup and JS additions mirror the tag editor used on the main page for feature parity.

### Testing
- Ran `python -m py_compile app.py` to validate Python syntax; the check succeeded.
- Launched the app with `python app.py` and exercised the UI via an automated Playwright script which verified that the tickets table shows the `View ticket` and `View analysis` buttons and that the bookmarklet form accepts tags using `Tab`; the Playwright run completed and produced screenshots (`artifacts/index-buttons.png`, `artifacts/bookmarklet-tags.png`).
- All automated checks and the Playwright validation completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8a01ec1a4832b97b51e8c712017d4)