### PR TITLE
Add appearance settings page for colors, Google Fonts, and favicon uploads

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,15 +2,31 @@ from __future__ import annotations
 
 import sqlite3
 import csv
+import re
 from io import StringIO
 from datetime import datetime, date
 from pathlib import Path
 from typing import Any
+from urllib.parse import parse_qs, unquote, urlparse
+from uuid import uuid4
 
 from flask import Flask, Response, g, redirect, render_template, request, url_for
+from werkzeug.utils import secure_filename
 
 BASE_DIR = Path(__file__).resolve().parent
 DATABASE = BASE_DIR / "tickets.db"
+FAVICON_UPLOAD_DIR = BASE_DIR / "static" / "uploads"
+
+DEFAULT_APPEARANCE_SETTINGS = {
+    "primary_color": "#1565c0",
+    "background_color": "#ffffff",
+    "text_color": "#222222",
+    "font_css_url": "",
+    "font_family": "Arial, sans-serif",
+    "favicon_path": "",
+}
+
+ALLOWED_FAVICON_EXTENSIONS = {"ico", "png", "svg", "jpg", "jpeg", "webp"}
 
 app = Flask(__name__)
 
@@ -36,6 +52,14 @@ def init_db() -> None:
         CREATE TABLE IF NOT EXISTS categories (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             name TEXT UNIQUE NOT NULL
+        )
+        """
+    )
+    db.execute(
+        """
+        CREATE TABLE IF NOT EXISTS app_settings (
+            key TEXT PRIMARY KEY,
+            value TEXT NOT NULL
         )
         """
     )
@@ -82,6 +106,52 @@ def init_db() -> None:
 
     db.commit()
     db.close()
+
+
+def _extract_font_family(font_css_url: str) -> str:
+    parsed = urlparse(font_css_url)
+    if parsed.netloc != "fonts.googleapis.com" or not parsed.path.startswith("/css2"):
+        return ""
+
+    family_values = parse_qs(parsed.query).get("family", [])
+    if not family_values:
+        return ""
+
+    first_family = unquote(family_values[0]).split(":", maxsplit=1)[0]
+    cleaned = re.sub(r"\+", " ", first_family).strip()
+    return cleaned
+
+
+def _is_valid_hex_color(color_value: str) -> bool:
+    return bool(re.match(r"^#[0-9a-fA-F]{6}$", color_value))
+
+
+def get_app_settings(db: sqlite3.Connection) -> dict[str, str]:
+    rows = db.execute("SELECT key, value FROM app_settings").fetchall()
+    settings = dict(DEFAULT_APPEARANCE_SETTINGS)
+    for row in rows:
+        settings[row["key"]] = row["value"]
+    return settings
+
+
+def save_app_setting(db: sqlite3.Connection, key: str, value: str) -> None:
+    db.execute(
+        """
+        INSERT INTO app_settings (key, value)
+        VALUES (?, ?)
+        ON CONFLICT(key) DO UPDATE SET value = excluded.value
+        """,
+        (key, value),
+    )
+
+
+@app.context_processor
+def inject_appearance_settings() -> dict[str, dict[str, str]]:
+    db = get_db()
+    settings = get_app_settings(db)
+    favicon_path = settings.get("favicon_path", "")
+    settings["favicon_url"] = url_for("static", filename=favicon_path) if favicon_path else ""
+    return {"appearance_settings": settings}
 
 
 def _parse_tags(raw_tags: str) -> list[str]:
@@ -504,6 +574,60 @@ def add_category() -> Any:
     db.execute("INSERT OR IGNORE INTO categories (name) VALUES (?)", (name,))
     db.commit()
     return redirect(url_for("index"))
+
+
+@app.route("/settings", methods=["GET", "POST"])
+def appearance_settings() -> str:
+    db = get_db()
+    settings = get_app_settings(db)
+    message = ""
+    error = ""
+
+    if request.method == "POST":
+        primary_color = request.form.get("primary_color", settings["primary_color"]).strip()
+        background_color = request.form.get("background_color", settings["background_color"]).strip()
+        text_color = request.form.get("text_color", settings["text_color"]).strip()
+        font_css_url = request.form.get("font_css_url", "").strip()
+
+        if not all(
+            _is_valid_hex_color(value)
+            for value in (primary_color, background_color, text_color)
+        ):
+            error = "Colors must be valid 6-digit hex values."
+        elif font_css_url and not font_css_url.startswith("https://fonts.googleapis.com/css2"):
+            error = "Google Fonts URL must start with https://fonts.googleapis.com/css2"
+        else:
+            save_app_setting(db, "primary_color", primary_color)
+            save_app_setting(db, "background_color", background_color)
+            save_app_setting(db, "text_color", text_color)
+            save_app_setting(db, "font_css_url", font_css_url)
+            save_app_setting(
+                db,
+                "font_family",
+                f"'{_extract_font_family(font_css_url)}', Arial, sans-serif" if font_css_url else DEFAULT_APPEARANCE_SETTINGS["font_family"],
+            )
+
+            favicon_file = request.files.get("favicon")
+            if favicon_file and favicon_file.filename:
+                extension = favicon_file.filename.rsplit(".", maxsplit=1)[-1].lower() if "." in favicon_file.filename else ""
+                if extension not in ALLOWED_FAVICON_EXTENSIONS:
+                    error = "Unsupported favicon type. Use .ico, .png, .svg, .jpg, .jpeg, or .webp"
+                else:
+                    FAVICON_UPLOAD_DIR.mkdir(parents=True, exist_ok=True)
+                    safe_name = secure_filename(favicon_file.filename)
+                    new_name = f"{uuid4().hex}-{safe_name}"
+                    upload_path = FAVICON_UPLOAD_DIR / new_name
+                    favicon_file.save(upload_path)
+                    save_app_setting(db, "favicon_path", f"uploads/{new_name}")
+
+            if not error:
+                db.commit()
+                return redirect(url_for("appearance_settings", saved="1"))
+
+    if request.args.get("saved") == "1":
+        message = "Appearance settings updated."
+
+    return render_template("settings.html", settings=settings, message=message, error=error)
 
 
 if __name__ == "__main__":

--- a/templates/bookmarklet_form.html
+++ b/templates/bookmarklet_form.html
@@ -4,13 +4,21 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Quick Add Ticket</title>
+  {% if appearance_settings['favicon_url'] %}
+    <link rel="icon" href="{{ appearance_settings['favicon_url'] }}" />
+  {% endif %}
+  {% if appearance_settings['font_css_url'] %}
+    <link rel="stylesheet" href="{{ appearance_settings['font_css_url'] }}" />
+  {% endif %}
   <style>
     body {
-      font-family: Arial, sans-serif;
+      font-family: {{ appearance_settings['font_family'] }};
       max-width: 720px;
       margin: 2rem auto;
       padding: 0 1rem;
       line-height: 1.4;
+      color: {{ appearance_settings['text_color'] }};
+      background: {{ appearance_settings['background_color'] }};
     }
 
     form {

--- a/templates/index.html
+++ b/templates/index.html
@@ -4,9 +4,22 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Ticket Tracker</title>
+  {% if appearance_settings['favicon_url'] %}
+    <link rel="icon" href="{{ appearance_settings['favicon_url'] }}" />
+  {% endif %}
+  {% if appearance_settings['font_css_url'] %}
+    <link rel="stylesheet" href="{{ appearance_settings['font_css_url'] }}" />
+  {% endif %}
   <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
   <style>
-    body { font-family: Arial, sans-serif; margin: 2rem; color: #222; }
+    :root {
+      --primary-color: {{ appearance_settings['primary_color'] }};
+      --primary-color-hover: color-mix(in srgb, var(--primary-color) 85%, black);
+      --background-color: {{ appearance_settings['background_color'] }};
+      --text-color: {{ appearance_settings['text_color'] }};
+      --app-font-family: {{ appearance_settings['font_family'] }};
+    }
+    body { font-family: var(--app-font-family); margin: 2rem; color: var(--text-color); background: var(--background-color); }
     h1, h2 { margin-bottom: 0.5rem; }
     .layout { display: grid; grid-template-columns: minmax(340px, 1fr); gap: 1rem; margin-bottom: 1rem; align-items: start; }
     form { border: 1px solid #ddd; border-radius: 8px; padding: 1rem; background: #f9f9f9; }
@@ -21,16 +34,16 @@
       justify-content: center;
       width: auto;
       padding: 0.5rem 0.85rem;
-      border: 1px solid #1f5fbf;
+      border: 1px solid var(--primary-color);
       border-radius: 6px;
-      background: #1565c0;
+      background: var(--primary-color);
       color: #fff;
       text-decoration: none;
       font-size: 0.95rem;
       line-height: 1.2;
     }
-    .btn:hover { background: #0f4f96; }
-    .btn.secondary { background: #fff; color: #1565c0; }
+    .btn:hover { background: var(--primary-color-hover); }
+    .btn.secondary { background: #fff; color: var(--primary-color); }
     .btn.secondary:hover { background: #edf4ff; }
     textarea { min-height: 80px; }
     .analysis-input { min-height: 180px; }
@@ -83,7 +96,7 @@
     .add-ticket-panel summary::after {
       content: '▸';
       font-size: 1rem;
-      color: #1565c0;
+      color: var(--primary-color);
       transition: transform 0.15s ease-in-out;
     }
     .add-ticket-panel[open] summary::after { transform: rotate(90deg); }
@@ -111,6 +124,7 @@
 </head>
 <body>
   <h1>Ticket Tracker</h1>
+  <p><a class="btn secondary" href="{{ url_for('appearance_settings') }}">Customize appearance</a></p>
 
   <div class="layout">
     <form action="{{ url_for('add_ticket') }}" method="post">

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -1,0 +1,106 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Appearance Settings</title>
+  {% if appearance_settings['favicon_url'] %}
+    <link rel="icon" href="{{ appearance_settings['favicon_url'] }}" />
+  {% endif %}
+  {% if appearance_settings['font_css_url'] %}
+    <link rel="stylesheet" href="{{ appearance_settings['font_css_url'] }}" />
+  {% endif %}
+  <style>
+    :root {
+      --primary-color: {{ appearance_settings['primary_color'] }};
+      --background-color: {{ appearance_settings['background_color'] }};
+      --text-color: {{ appearance_settings['text_color'] }};
+      --app-font-family: {{ appearance_settings['font_family'] }};
+    }
+
+    body {
+      font-family: var(--app-font-family);
+      margin: 2rem auto;
+      max-width: 760px;
+      padding: 0 1rem;
+      color: var(--text-color);
+      background: var(--background-color);
+    }
+
+    form {
+      border: 1px solid #ddd;
+      border-radius: 8px;
+      padding: 1rem;
+      background: #f9f9f9;
+      display: grid;
+      gap: 0.75rem;
+    }
+
+    label { font-weight: bold; }
+    input, button { padding: 0.5rem; }
+    .btn {
+      width: fit-content;
+      border: 1px solid var(--primary-color);
+      background: var(--primary-color);
+      color: white;
+      border-radius: 6px;
+      cursor: pointer;
+      text-decoration: none;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+    }
+    .btn.secondary {
+      background: white;
+      color: var(--primary-color);
+    }
+    .msg { padding: 0.6rem; border-radius: 6px; margin: 0.5rem 0; }
+    .msg.success { border: 1px solid #56a46b; background: #e8f8ec; }
+    .msg.error { border: 1px solid #c66a6a; background: #fdecec; }
+    .row { display: flex; gap: 0.6rem; align-items: center; flex-wrap: wrap; }
+  </style>
+</head>
+<body>
+  <h1>Customize Appearance</h1>
+  <p><a class="btn secondary" href="{{ url_for('index') }}">← Back to tickets</a></p>
+
+  {% if message %}
+    <div class="msg success">{{ message }}</div>
+  {% endif %}
+
+  {% if error %}
+    <div class="msg error">{{ error }}</div>
+  {% endif %}
+
+  <form action="{{ url_for('appearance_settings') }}" method="post" enctype="multipart/form-data">
+    <label for="primary_color">Primary color</label>
+    <input id="primary_color" name="primary_color" type="color" value="{{ settings['primary_color'] }}" required />
+
+    <label for="background_color">Background color</label>
+    <input id="background_color" name="background_color" type="color" value="{{ settings['background_color'] }}" required />
+
+    <label for="text_color">Text color</label>
+    <input id="text_color" name="text_color" type="color" value="{{ settings['text_color'] }}" required />
+
+    <label for="font_css_url">Google Fonts CSS2 URL</label>
+    <input
+      id="font_css_url"
+      name="font_css_url"
+      type="url"
+      value="{{ settings['font_css_url'] }}"
+      placeholder="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap"
+    />
+
+    <label for="favicon">Upload favicon</label>
+    <input id="favicon" name="favicon" type="file" accept=".ico,.png,.svg,.jpg,.jpeg,.webp" />
+
+    <div class="row">
+      <button class="btn" type="submit">Save appearance</button>
+      {% if appearance_settings['favicon_url'] %}
+        <span>Current favicon:</span>
+        <img src="{{ appearance_settings['favicon_url'] }}" alt="Current favicon" width="24" height="24" />
+      {% endif %}
+    </div>
+  </form>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Provide a simple UI to customize the app look (primary/background/text colors, page font via Google Fonts CSS2, and a favicon) and persist those choices across runs.

### Description
- Persist appearance settings in a new `app_settings` SQLite table and add helper functions `get_app_settings` and `save_app_setting` plus utilities to validate hex colors and extract a font family from a Google Fonts CSS2 URL in `app.py`.
- Add a new `/settings` route and `templates/settings.html` to let users set `primary_color`, `background_color`, `text_color`, a Google Fonts CSS2 URL, and upload a favicon; uploaded favicons are stored under `static/uploads/` and referenced from settings.
- Inject appearance settings globally via a Flask context processor and apply them to `templates/index.html` and `templates/bookmarklet_form.html` by adding the favicon link, optional Google Fonts stylesheet, CSS variables, and a “Customize appearance” entry point.
- Add server-side validation for colors and Google Fonts URL format, secure the uploaded favicon filename, and record a derived `font_family` to use in styles.

### Testing
- Ran `python -m py_compile app.py` to verify syntax and it succeeded.
- Exercised the `/settings` endpoint with a Flask test client including a multipart favicon upload and verified the POST returned a redirect and the main page rendered the new customization link (test assertions passed).
- Used `curl` to GET `/settings` and to POST form data with a favicon file and observed a `200` for the GET and a `302` redirect for the POST, both succeeding.
- Captured a rendered screenshot of `/settings?saved=1` via an automated Playwright script to visually validate the page rendering, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8a3f24dfc832b9cde250480cb5630)