### PR TITLE
Simplify appearance settings to site title and accent color

### DIFF
--- a/app.py
+++ b/app.py
@@ -7,17 +7,13 @@ from io import StringIO
 from datetime import datetime, date
 from pathlib import Path
 from typing import Any
-from urllib.parse import parse_qs, unquote, urlparse
-from uuid import uuid4
 
 from flask import Flask, Response, g, redirect, render_template, request, url_for
-from werkzeug.utils import secure_filename
 
 BASE_DIR = Path(__file__).resolve().parent
 DATABASE = BASE_DIR / "tickets.db"
-FAVICON_UPLOAD_DIR = BASE_DIR / "static" / "uploads"
-
 DEFAULT_APPEARANCE_SETTINGS = {
+    "site_title": "Ticket Tracker",
     "primary_color": "#1565c0",
     "background_color": "#ffffff",
     "text_color": "#222222",
@@ -25,8 +21,6 @@ DEFAULT_APPEARANCE_SETTINGS = {
     "font_family": "Arial, sans-serif",
     "favicon_path": "",
 }
-
-ALLOWED_FAVICON_EXTENSIONS = {"ico", "png", "svg", "jpg", "jpeg", "webp"}
 
 app = Flask(__name__)
 
@@ -106,20 +100,6 @@ def init_db() -> None:
 
     db.commit()
     db.close()
-
-
-def _extract_font_family(font_css_url: str) -> str:
-    parsed = urlparse(font_css_url)
-    if parsed.netloc != "fonts.googleapis.com" or not parsed.path.startswith("/css2"):
-        return ""
-
-    family_values = parse_qs(parsed.query).get("family", [])
-    if not family_values:
-        return ""
-
-    first_family = unquote(family_values[0]).split(":", maxsplit=1)[0]
-    cleaned = re.sub(r"\+", " ", first_family).strip()
-    return cleaned
 
 
 def _is_valid_hex_color(color_value: str) -> bool:
@@ -584,45 +564,18 @@ def appearance_settings() -> str:
     error = ""
 
     if request.method == "POST":
+        site_title = request.form.get("site_title", settings["site_title"]).strip()
         primary_color = request.form.get("primary_color", settings["primary_color"]).strip()
-        background_color = request.form.get("background_color", settings["background_color"]).strip()
-        text_color = request.form.get("text_color", settings["text_color"]).strip()
-        font_css_url = request.form.get("font_css_url", "").strip()
 
-        if not all(
-            _is_valid_hex_color(value)
-            for value in (primary_color, background_color, text_color)
-        ):
-            error = "Colors must be valid 6-digit hex values."
-        elif font_css_url and not font_css_url.startswith("https://fonts.googleapis.com/css2"):
-            error = "Google Fonts URL must start with https://fonts.googleapis.com/css2"
+        if not site_title:
+            error = "Site title cannot be empty."
+        elif not _is_valid_hex_color(primary_color):
+            error = "Accent color must be a valid 6-digit hex value."
         else:
+            save_app_setting(db, "site_title", site_title)
             save_app_setting(db, "primary_color", primary_color)
-            save_app_setting(db, "background_color", background_color)
-            save_app_setting(db, "text_color", text_color)
-            save_app_setting(db, "font_css_url", font_css_url)
-            save_app_setting(
-                db,
-                "font_family",
-                f"'{_extract_font_family(font_css_url)}', Arial, sans-serif" if font_css_url else DEFAULT_APPEARANCE_SETTINGS["font_family"],
-            )
-
-            favicon_file = request.files.get("favicon")
-            if favicon_file and favicon_file.filename:
-                extension = favicon_file.filename.rsplit(".", maxsplit=1)[-1].lower() if "." in favicon_file.filename else ""
-                if extension not in ALLOWED_FAVICON_EXTENSIONS:
-                    error = "Unsupported favicon type. Use .ico, .png, .svg, .jpg, .jpeg, or .webp"
-                else:
-                    FAVICON_UPLOAD_DIR.mkdir(parents=True, exist_ok=True)
-                    safe_name = secure_filename(favicon_file.filename)
-                    new_name = f"{uuid4().hex}-{safe_name}"
-                    upload_path = FAVICON_UPLOAD_DIR / new_name
-                    favicon_file.save(upload_path)
-                    save_app_setting(db, "favicon_path", f"uploads/{new_name}")
-
-            if not error:
-                db.commit()
-                return redirect(url_for("appearance_settings", saved="1"))
+            db.commit()
+            return redirect(url_for("appearance_settings", saved="1"))
 
     if request.args.get("saved") == "1":
         message = "Appearance settings updated."

--- a/templates/bookmarklet_form.html
+++ b/templates/bookmarklet_form.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Quick Add Ticket</title>
+  <title>Quick Add · {{ appearance_settings['site_title'] }}</title>
   {% if appearance_settings['favicon_url'] %}
     <link rel="icon" href="{{ appearance_settings['favicon_url'] }}" />
   {% endif %}
@@ -113,7 +113,7 @@
   </style>
 </head>
 <body>
-  <h1>Quick Add Ticket</h1>
+  <h1>Quick Add · {{ appearance_settings['site_title'] }}</h1>
   <p>This form is intended for bookmarklet usage. It pre-fills the current page URL as the ticket link.</p>
 
   {% if success %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Ticket Tracker</title>
+  <title>{{ appearance_settings['site_title'] }}</title>
   {% if appearance_settings['favicon_url'] %}
     <link rel="icon" href="{{ appearance_settings['favicon_url'] }}" />
   {% endif %}
@@ -123,7 +123,7 @@
   </style>
 </head>
 <body>
-  <h1>Ticket Tracker</h1>
+  <h1>{{ appearance_settings['site_title'] }}</h1>
   <p><a class="btn secondary" href="{{ url_for('appearance_settings') }}">Customize appearance</a></p>
 
   <div class="layout">

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -3,43 +3,71 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Appearance Settings</title>
+  <title>Customize · {{ appearance_settings['site_title'] }}</title>
   {% if appearance_settings['favicon_url'] %}
     <link rel="icon" href="{{ appearance_settings['favicon_url'] }}" />
-  {% endif %}
-  {% if appearance_settings['font_css_url'] %}
-    <link rel="stylesheet" href="{{ appearance_settings['font_css_url'] }}" />
   {% endif %}
   <style>
     :root {
       --primary-color: {{ appearance_settings['primary_color'] }};
-      --background-color: {{ appearance_settings['background_color'] }};
-      --text-color: {{ appearance_settings['text_color'] }};
-      --app-font-family: {{ appearance_settings['font_family'] }};
     }
 
     body {
-      font-family: var(--app-font-family);
+      font-family: Arial, sans-serif;
       margin: 2rem auto;
       max-width: 760px;
       padding: 0 1rem;
-      color: var(--text-color);
-      background: var(--background-color);
+      color: #1f2937;
+      background: #f3f4f6;
     }
 
     form {
-      border: 1px solid #ddd;
+      border: 1px solid #d1d5db;
       border-radius: 8px;
       padding: 1rem;
-      background: #f9f9f9;
+      background: #ffffff;
       display: grid;
-      gap: 0.75rem;
+      gap: 0.9rem;
     }
 
     label { font-weight: bold; }
-    input, button { padding: 0.5rem; }
+
+    input[type="text"] {
+      width: 100%;
+      box-sizing: border-box;
+      padding: 0.55rem;
+      border: 1px solid #cbd5e1;
+      border-radius: 6px;
+    }
+
+    input[type="color"] {
+      width: 64px;
+      height: 40px;
+      border: 0;
+      padding: 0;
+      background: none;
+      cursor: pointer;
+    }
+
+    .color-row {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+    }
+
+    .color-code {
+      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+      background: #f3f4f6;
+      border: 1px solid #d1d5db;
+      border-radius: 6px;
+      padding: 0.25rem 0.5rem;
+      min-width: 80px;
+      text-transform: uppercase;
+    }
+
     .btn {
       width: fit-content;
+      padding: 0.55rem 0.9rem;
       border: 1px solid var(--primary-color);
       background: var(--primary-color);
       color: white;
@@ -50,14 +78,15 @@
       align-items: center;
       justify-content: center;
     }
+
     .btn.secondary {
       background: white;
       color: var(--primary-color);
     }
+
     .msg { padding: 0.6rem; border-radius: 6px; margin: 0.5rem 0; }
     .msg.success { border: 1px solid #56a46b; background: #e8f8ec; }
     .msg.error { border: 1px solid #c66a6a; background: #fdecec; }
-    .row { display: flex; gap: 0.6rem; align-items: center; flex-wrap: wrap; }
   </style>
 </head>
 <body>
@@ -72,35 +101,26 @@
     <div class="msg error">{{ error }}</div>
   {% endif %}
 
-  <form action="{{ url_for('appearance_settings') }}" method="post" enctype="multipart/form-data">
-    <label for="primary_color">Primary color</label>
-    <input id="primary_color" name="primary_color" type="color" value="{{ settings['primary_color'] }}" required />
+  <form action="{{ url_for('appearance_settings') }}" method="post">
+    <label for="site_title">Site title</label>
+    <input id="site_title" name="site_title" type="text" value="{{ settings['site_title'] }}" maxlength="80" required />
 
-    <label for="background_color">Background color</label>
-    <input id="background_color" name="background_color" type="color" value="{{ settings['background_color'] }}" required />
-
-    <label for="text_color">Text color</label>
-    <input id="text_color" name="text_color" type="color" value="{{ settings['text_color'] }}" required />
-
-    <label for="font_css_url">Google Fonts CSS2 URL</label>
-    <input
-      id="font_css_url"
-      name="font_css_url"
-      type="url"
-      value="{{ settings['font_css_url'] }}"
-      placeholder="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap"
-    />
-
-    <label for="favicon">Upload favicon</label>
-    <input id="favicon" name="favicon" type="file" accept=".ico,.png,.svg,.jpg,.jpeg,.webp" />
-
-    <div class="row">
-      <button class="btn" type="submit">Save appearance</button>
-      {% if appearance_settings['favicon_url'] %}
-        <span>Current favicon:</span>
-        <img src="{{ appearance_settings['favicon_url'] }}" alt="Current favicon" width="24" height="24" />
-      {% endif %}
+    <label for="primary_color">Accent color</label>
+    <div class="color-row">
+      <input id="primary_color" name="primary_color" type="color" value="{{ settings['primary_color'] }}" required />
+      <span id="color-code" class="color-code">{{ settings['primary_color'] }}</span>
     </div>
+
+    <button class="btn" type="submit">Save settings</button>
   </form>
+
+  <script>
+    const colorInput = document.getElementById('primary_color');
+    const colorCode = document.getElementById('color-code');
+
+    colorInput.addEventListener('input', () => {
+      colorCode.textContent = colorInput.value.toUpperCase();
+    });
+  </script>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- The settings UI needed to be simplified so users can only change the site title and the accent color and can immediately see the chosen color.
- Persist a configurable site title so the app tab title and on-page heading reflect the stored value.

### Description
- Added a persisted `site_title` default to `DEFAULT_APPEARANCE_SETTINGS` and save/validate `site_title` in the `/settings` handler.
- Reduced `/settings` to accept and persist only `site_title` and `primary_color`, removed background/text/font/favicon controls and related upload/parse code and imports.
- Templates updated to use `appearance_settings['site_title']` for page `<title>` and main/quick-add headings, and the settings page now shows a color picker with a live hex readout beside it.
- Added validation that `site_title` is not empty and that `primary_color` is a valid 6-digit hex color using `_is_valid_hex_color`.

### Testing
- Ran `python -m py_compile app.py` to verify the module compiles successfully (passed).
- Launched the app and ran a Playwright script to open `/settings` and capture a screenshot to confirm the updated UI rendered (screenshot artifact produced and UI inspected successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8a56da9a8832ba89beb9e2770f837)