### PR TITLE
Render ticket dates as human-readable text in tickets table

### DIFF
--- a/app.py
+++ b/app.py
@@ -115,6 +115,11 @@ def _sync_ticket_tags(db: sqlite3.Connection, ticket_id: int, tag_names: list[st
         )
 
 
+def _human_readable_date(raw_date: str) -> str:
+    parsed_date = datetime.strptime(raw_date, "%Y-%m-%d")
+    return f"{parsed_date:%B} {parsed_date.day}, {parsed_date:%Y}"
+
+
 def _validated_ticket_fields(form: Any) -> tuple[str, str, str, str, str, int, int, list[str]] | None:
     link = form.get("link", "").strip()
     category_id = form.get("category_id", "").strip()
@@ -194,7 +199,7 @@ def index() -> str:
     where_sql = f"WHERE {' AND '.join(where_clauses)}" if where_clauses else ""
 
     db = get_db()
-    tickets = db.execute(
+    ticket_rows = db.execute(
         f"""
         SELECT t.id, t.link, c.name AS category, t.description, t.date,
                t.ai_analysis, t.shared_with_manager, t.favorite,
@@ -209,6 +214,12 @@ def index() -> str:
         """,
         params,
     ).fetchall()
+
+    tickets = []
+    for ticket in ticket_rows:
+        ticket_dict = dict(ticket)
+        ticket_dict["display_date"] = _human_readable_date(ticket_dict["date"])
+        tickets.append(ticket_dict)
 
     categories = db.execute("SELECT id, name FROM categories ORDER BY name ASC").fetchall()
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -261,7 +261,7 @@
         </td>
         <td>{{ ticket['category'] }}</td>
         <td>{{ ticket['description'] }}</td>
-        <td>{{ ticket['date'] }}</td>
+        <td>{{ ticket['display_date'] }}</td>
         <td class="analysis-cell">
           {% if ticket['ai_analysis'] %}
             <button


### PR DESCRIPTION
### Motivation
- Improve UX by displaying stored ISO dates (`YYYY-MM-DD`) in a human-readable format like `March 3, 2026` in the tickets table.
- Keep the stored date format unchanged so data and sorting remain consistent while improving presentation.

### Description
- Add `_human_readable_date(raw_date: str) -> str` helper that parses `YYYY-MM-DD` and formats it as `MonthName day, Year` in `app.py`.
- In the index route, fetch rows as `ticket_rows`, convert each row to a dict and attach `display_date` using the new helper, then pass `tickets` to the template.
- Update `templates/index.html` to render `ticket['display_date']` in the Date column instead of the raw ISO date.

### Testing
- Ran `pytest -q` which discovered no tests in the repository (no tests ran).
- Ran `python -m compileall app.py` which succeeded and verified the module compiles.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8a90f94bc832b91f03c4ffdb83b99)