### PR TITLE
Refine tag chip layout to fit tag text

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -107,6 +107,11 @@
     .tag-editor input { border: 0; outline: none; min-width: 180px; flex: 1; padding: 0.35rem; }
     .tag-bubble { display: inline-flex; align-items: center; gap: 0.4rem; background: #e8f0fe; color: #113a8f; border-radius: 999px; padding: 0.2rem 0.55rem; font-size: 0.9rem; }
     .tag-bubble button { width: auto; border: 0; background: transparent; color: inherit; cursor: pointer; padding: 0; line-height: 1; font-size: 1rem; }
+    button.tag-bubble {
+      width: auto;
+      max-width: 100%;
+      flex: 0 0 auto;
+    }
     .tag-bubble.filter-tag {
       border: 1px solid #b9d0ff;
       cursor: pointer;


### PR DESCRIPTION
### Motivation
- Make tag UI more compact and readable by ensuring tag buttons size to their text instead of stretching to the column width.

### Description
- Added a CSS rule in `templates/index.html` so tag buttons render as compact bubbles: `button.tag-bubble { width: auto; max-width: 100%; flex: 0 0 auto; }` while keeping the existing `.tag-bubble` visual treatment.
- Seeded local test records in the SQLite DB and captured a screenshot to validate the updated tag layout visually.

### Testing
- Ran `python -m py_compile app.py` which succeeded.
- Executed the DB seed script via `python - <<'PY'` to insert sample tickets and then started the app with `python app.py` for manual verification, and used a Playwright capture to produce `artifacts/tag-bubble-update.png`, all of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9b941f6e0832b86b09b4c239aa2dc)