### PR TITLE
Add "Clear all filters" control to Saved Tickets filter bar

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -398,6 +398,7 @@
       <input id="date_to" name="date_to" type="date" value="{{ date_to }}" aria-label="To date" />
 
       <button class="btn" type="submit">Apply</button>
+      <a class="btn secondary" href="{{ url_for('index') }}">Clear all filters</a>
       <button class="btn secondary" type="submit" formaction="{{ url_for('export_tickets') }}" formmethod="get">Export CSV</button>
     </form>
   </div>


### PR DESCRIPTION
### Motivation
- Provide a quick way for users to reset all query-based filters in the Saved Tickets controls and return to the unfiltered index view in one click.

### Description
- Add a `Clear all filters` secondary button that links to `url_for('index')` in `templates/index.html`, placed beside the existing `Apply` and `Export CSV` controls to remove all active filter query parameters.

### Testing
- Automated checks: `python -m py_compile app.py` and an automated Playwright screenshot script against the running dev server both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b10c6e66a8832bbeb9d18688615a52)