### PR TITLE
Bookmarklet: add new-category option; bubble-style tag filter; friendly ticket link labels

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,10 +2,12 @@ from __future__ import annotations
 
 import sqlite3
 import csv
+import re
 from io import StringIO
 from datetime import datetime, date
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlparse
 
 from flask import Flask, Response, g, redirect, render_template, request, url_for
 
@@ -131,6 +133,46 @@ def _validated_filter_date(raw_date: str) -> str:
         return ""
 
     return normalized_date
+
+
+def _ticket_link_label(link: str) -> str:
+    parsed_link = urlparse(link)
+    host = parsed_link.netloc.lower()
+    path = parsed_link.path.strip("/")
+
+    if "zendesk" in host:
+        match = re.search(r"/tickets/(\d+)", parsed_link.path, re.IGNORECASE)
+        if match:
+            return f"ZD {match.group(1)}"
+
+    if "atlassian" in host:
+        ticket_key = path.rsplit("/", maxsplit=1)[-1]
+        match = re.fullmatch(r"([A-Za-z]+)-(\d+)", ticket_key)
+        if match:
+            return f"{match.group(1).upper()} {match.group(2)}"
+
+    return "Ticket"
+
+
+def _get_or_create_category_id(db: sqlite3.Connection, category_id: str, new_category_name: str) -> str:
+    normalized_category_id = category_id.strip()
+    normalized_new_category = new_category_name.strip()
+
+    if normalized_category_id:
+        return normalized_category_id
+
+    if not normalized_new_category:
+        return ""
+
+    db.execute("INSERT OR IGNORE INTO categories (name) VALUES (?)", (normalized_new_category,))
+    category_row = db.execute(
+        "SELECT id FROM categories WHERE LOWER(name) = LOWER(?)",
+        (normalized_new_category,),
+    ).fetchone()
+    if category_row is None:
+        return ""
+
+    return str(category_row["id"])
 
 
 def _build_ticket_filters(args: Any) -> tuple[list[str], list[Any], dict[str, Any]]:
@@ -262,6 +304,7 @@ def index() -> str:
     for ticket in ticket_rows:
         ticket_dict = dict(ticket)
         ticket_dict["display_date"] = _human_readable_date(ticket_dict["date"])
+        ticket_dict["link_label"] = _ticket_link_label(ticket_dict["link"])
         tickets.append(ticket_dict)
 
     categories = db.execute("SELECT id, name FROM categories ORDER BY name ASC").fetchall()
@@ -416,24 +459,35 @@ def bookmarklet_add_ticket() -> str:
                 "tags": "",
                 "date": date.today().isoformat(),
                 "category_id": "",
+                "new_category_name": "",
                 "shared_with_manager": False,
                 "favorite": False,
             },
         )
 
-    ticket_fields = _validated_ticket_fields(request.form)
+    selected_category_id = _get_or_create_category_id(
+        db,
+        request.form.get("category_id", ""),
+        request.form.get("new_category_name", ""),
+    )
+    submitted_form = request.form.copy()
+    submitted_form["category_id"] = selected_category_id
+
+    ticket_fields = _validated_ticket_fields(submitted_form)
     form_values = {
         "link": request.form.get("link", "").strip(),
         "description": request.form.get("description", "").strip(),
         "ai_analysis": request.form.get("ai_analysis", ""),
         "tags": request.form.get("tags", ""),
         "date": request.form.get("date", "").strip(),
-        "category_id": request.form.get("category_id", "").strip(),
+        "category_id": selected_category_id,
+        "new_category_name": request.form.get("new_category_name", "").strip(),
         "shared_with_manager": request.form.get("shared_with_manager") == "on",
         "favorite": request.form.get("favorite") == "on",
     }
 
     if ticket_fields is None:
+        categories = db.execute("SELECT id, name FROM categories ORDER BY name ASC").fetchall()
         return render_template(
             "bookmarklet_form.html",
             categories=categories,
@@ -459,10 +513,12 @@ def bookmarklet_add_ticket() -> str:
             "description": "",
             "ai_analysis": "",
             "tags": "",
+            "new_category_name": "",
             "shared_with_manager": False,
             "favorite": False,
         }
     )
+    categories = db.execute("SELECT id, name FROM categories ORDER BY name ASC").fetchall()
     return render_template(
         "bookmarklet_form.html",
         categories=categories,

--- a/templates/bookmarklet_form.html
+++ b/templates/bookmarklet_form.html
@@ -151,7 +151,7 @@
     <input id="link" name="link" type="url" value="{{ form_values['link'] }}" required />
 
     <label for="category_id">Category</label>
-    <select id="category_id" name="category_id" required>
+    <select id="category_id" name="category_id">
       <option value="">Select category</option>
       {% for category in categories %}
         <option value="{{ category['id'] }}" {% if form_values['category_id'] == category['id']|string %}selected{% endif %}>
@@ -159,6 +159,15 @@
         </option>
       {% endfor %}
     </select>
+
+    <label for="new_category_name">Or add new category</label>
+    <input
+      id="new_category_name"
+      name="new_category_name"
+      type="text"
+      placeholder="e.g. Investigation"
+      value="{{ form_values.get('new_category_name', '') }}"
+    />
 
     <label for="description">Description</label>
     <textarea id="description" name="description" required>{{ form_values['description'] }}</textarea>

--- a/templates/index.html
+++ b/templates/index.html
@@ -389,7 +389,10 @@
         Favorites only
       </label>
 
-      <input id="tags_filter" name="tags" type="text" placeholder="Filter by tags (comma separated)" value="{{ tag_filter }}" />
+      <input id="tags_filter" name="tags" type="hidden" value="{{ tag_filter }}" />
+      <div class="tag-editor" data-tag-editor data-hidden-input-id="tags_filter">
+        <input type="text" placeholder="Filter by tag" data-tag-input />
+      </div>
 
       <input id="date_from" name="date_from" type="date" value="{{ date_from }}" aria-label="From date" />
 
@@ -419,7 +422,7 @@
       {% for ticket in tickets %}
       <tr>
         <td class="ticket-link-cell">
-          <a class="btn secondary" href="{{ ticket['link'] }}" target="_blank" rel="noopener">Ticket</a>
+          <a class="btn secondary" href="{{ ticket['link'] }}" target="_blank" rel="noopener">{{ ticket['link_label'] }}</a>
         </td>
         <td>{{ ticket['category'] }}</td>
         <td>{{ ticket['description'] }}</td>
@@ -642,6 +645,8 @@
       });
 
       renderTags();
+
+      editor.refreshTagBubbles = renderTags;
     }
 
     document.querySelectorAll('[data-tag-editor]').forEach((editor) => {
@@ -675,6 +680,10 @@
         if (!isAlreadySelected) {
           selectedTags.push(clickedTag);
           tagsFilterInput.value = selectedTags.join(', ');
+          const editor = document.querySelector('[data-tag-editor][data-hidden-input-id="tags_filter"]');
+          if (editor && typeof editor.refreshTagBubbles === "function") {
+            editor.refreshTagBubbles();
+          }
         }
 
         filterForm.requestSubmit();


### PR DESCRIPTION
### Motivation
- Allow creating categories directly from the bookmarklet flow so users can add tickets without pre-creating a category. 
- Make tag filtering match the tag entry UI by using bubbles instead of a comma-separated text field. 
- Improve link button labels to surface ticket identifiers for Zendesk and Atlassian links for easier recognition. 

### Description
- Added a `new_category_name` input to the bookmarklet form and backend helper `_get_or_create_category_id` which resolves or creates the category before validation and saving. 
- Adjusted the bookmarklet POST flow to use the selected or newly-created category id when validating and inserting tickets. 
- Replaced the main tags filter text input with the same bubble-style tag editor used for tag entry (`data-tag-editor`) and exposed `editor.refreshTagBubbles` so tag-pill clicks update the visible filter bubbles. 
- Implemented `_ticket_link_label(link)` (using `urlparse` and `re`) to render `ZD <number>` for Zendesk ticket URLs and `<KEY> <number>` for Atlassian URLs (hyphen removed), falling back to `Ticket` for others, and used this label in the table link button. 
- Updated templates `templates/bookmarklet_form.html` and `templates/index.html` and added minor JS wiring to keep tag filter state and UI in sync. 

### Testing
- Compiled the app with `python -m compileall app.py` and the compile succeeded. 
- Launched the Flask app with `python app.py` and exercised the UI; the server started and served the updated pages. 
- Captured a UI screenshot using a Playwright script pointed at `http://127.0.0.1:5000/` to validate the visual changes and interactions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b111e68578832ba81ae156db4ea81f)