### PR TITLE
Fix clickable tag filters and normalize notes/entry naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Pack Tracker
 
-Simple Flask app for tracking tickets with:
-- ticket link
+Simple Flask app for tracking entries with:
+- entry link
 - category (with custom category creation)
 - description
 - date
 - description search
-- filters for favorite tickets
+- filters for favorite entries
 
 ## Run
 

--- a/app.py
+++ b/app.py
@@ -135,7 +135,7 @@ def _validated_filter_date(raw_date: str) -> str:
     return normalized_date
 
 
-def _ticket_link_label(link: str) -> str:
+def _entry_link_label(link: str) -> str:
     parsed_link = urlparse(link)
     host = parsed_link.netloc.lower()
     path = parsed_link.path.strip("/")
@@ -175,7 +175,7 @@ def _get_or_create_category_id(db: sqlite3.Connection, category_id: str, new_cat
     return str(category_row["id"])
 
 
-def _build_ticket_filters(args: Any) -> tuple[list[str], list[Any], dict[str, Any]]:
+def _build_entry_filters(args: Any) -> tuple[list[str], list[Any], dict[str, Any]]:
     description_search = args.get("q", "").strip()
     category_filter = args.get("category_id", "").strip()
     shared_only = args.get("shared_only", "0") == "1"
@@ -235,11 +235,11 @@ def _build_ticket_filters(args: Any) -> tuple[list[str], list[Any], dict[str, An
     return where_clauses, params, filter_state
 
 
-def _validated_ticket_fields(form: Any) -> tuple[str, str, str, str, str, int, int, list[str]] | None:
+def _validated_entry_fields(form: Any) -> tuple[str, str, str, str, str, int, int, list[str]] | None:
     link = form.get("link", "").strip()
     category_id = form.get("category_id", "").strip()
     description = form.get("description", "").strip()
-    ai_analysis = form.get("ai_analysis", "")
+    notes = form.get("ai_analysis", "")
     date_value = form.get("date", "").strip()
     shared_with_manager = 1 if form.get("shared_with_manager") == "on" else 0
     favorite = 1 if form.get("favorite") == "on" else 0
@@ -257,7 +257,7 @@ def _validated_ticket_fields(form: Any) -> tuple[str, str, str, str, str, int, i
         link,
         category_id,
         description,
-        ai_analysis,
+        notes,
         date_value,
         shared_with_manager,
         favorite,
@@ -279,7 +279,7 @@ def index() -> str:
     sort_column = allowed_sort.get(sort_by, "t.date")
     sort_order = "ASC" if order == "asc" else "DESC"
 
-    where_clauses, params, filter_state = _build_ticket_filters(request.args)
+    where_clauses, params, filter_state = _build_entry_filters(request.args)
 
     where_sql = f"WHERE {' AND '.join(where_clauses)}" if where_clauses else ""
 
@@ -287,7 +287,7 @@ def index() -> str:
     ticket_rows = db.execute(
         f"""
         SELECT t.id, t.link, c.name AS category, t.description, t.date,
-               t.ai_analysis, t.shared_with_manager, t.favorite,
+               t.ai_analysis AS notes, t.shared_with_manager, t.favorite,
                COALESCE(GROUP_CONCAT(tg.name, ', '), '') AS tags
         FROM tickets t
         JOIN categories c ON t.category_id = c.id
@@ -304,7 +304,7 @@ def index() -> str:
     for ticket in ticket_rows:
         ticket_dict = dict(ticket)
         ticket_dict["display_date"] = _human_readable_date(ticket_dict["date"])
-        ticket_dict["link_label"] = _ticket_link_label(ticket_dict["link"])
+        ticket_dict["link_label"] = _entry_link_label(ticket_dict["link"])
         tickets.append(ticket_dict)
 
     categories = db.execute("SELECT id, name FROM categories ORDER BY name ASC").fetchall()
@@ -313,7 +313,7 @@ def index() -> str:
     if edit_id.isdigit():
         ticket_to_edit = db.execute(
             """
-            SELECT id, link, category_id, description, ai_analysis, date, shared_with_manager, favorite
+            SELECT id, link, category_id, description, ai_analysis AS notes, date, shared_with_manager, favorite
             FROM tickets
             WHERE id = ?
             """,
@@ -347,7 +347,7 @@ def index() -> str:
 
 @app.route("/tickets/export", methods=["GET"])
 def export_tickets() -> Response:
-    where_clauses, params, _ = _build_ticket_filters(request.args)
+    where_clauses, params, _ = _build_entry_filters(request.args)
 
     where_sql = f"WHERE {' AND '.join(where_clauses)}" if where_clauses else ""
 
@@ -359,7 +359,7 @@ def export_tickets() -> Response:
                t.category_id,
                c.name AS category,
                t.description,
-               t.ai_analysis,
+               t.ai_analysis AS notes,
                t.date,
                t.shared_with_manager,
                t.favorite,
@@ -384,7 +384,7 @@ def export_tickets() -> Response:
             "category_id",
             "category",
             "description",
-            "ai_analysis",
+            "notes",
             "date",
             "shared_with_manager",
             "favorite",
@@ -400,7 +400,7 @@ def export_tickets() -> Response:
                 ticket["category_id"],
                 ticket["category"],
                 ticket["description"],
-                ticket["ai_analysis"],
+                ticket["notes"],
                 ticket["date"],
                 ticket["shared_with_manager"],
                 ticket["favorite"],
@@ -420,11 +420,11 @@ def export_tickets() -> Response:
 
 @app.route("/tickets", methods=["POST"])
 def add_ticket() -> Any:
-    ticket_fields = _validated_ticket_fields(request.form)
-    if ticket_fields is None:
+    entry_fields = _validated_entry_fields(request.form)
+    if entry_fields is None:
         return redirect(url_for("index"))
 
-    link, category_id, description, ai_analysis, date_value, shared_with_manager, favorite, tags = ticket_fields
+    link, category_id, description, notes, date_value, shared_with_manager, favorite, tags = entry_fields
 
     db = get_db()
     cursor = db.execute(
@@ -432,7 +432,7 @@ def add_ticket() -> Any:
         INSERT INTO tickets (link, category_id, description, ai_analysis, date, shared_with_manager, favorite)
         VALUES (?, ?, ?, ?, ?, ?, ?)
         """,
-        (link, category_id, description, ai_analysis, date_value, shared_with_manager, favorite),
+        (link, category_id, description, notes, date_value, shared_with_manager, favorite),
     )
     _sync_ticket_tags(db, cursor.lastrowid, tags)
     db.commit()
@@ -455,7 +455,7 @@ def bookmarklet_add_ticket() -> str:
             form_values={
                 "link": link,
                 "description": "",
-                "ai_analysis": "",
+                "notes": "",
                 "tags": "",
                 "date": date.today().isoformat(),
                 "category_id": "",
@@ -473,11 +473,11 @@ def bookmarklet_add_ticket() -> str:
     submitted_form = request.form.copy()
     submitted_form["category_id"] = selected_category_id
 
-    ticket_fields = _validated_ticket_fields(submitted_form)
+    entry_fields = _validated_entry_fields(submitted_form)
     form_values = {
         "link": request.form.get("link", "").strip(),
         "description": request.form.get("description", "").strip(),
-        "ai_analysis": request.form.get("ai_analysis", ""),
+        "notes": request.form.get("ai_analysis", ""),
         "tags": request.form.get("tags", ""),
         "date": request.form.get("date", "").strip(),
         "category_id": selected_category_id,
@@ -486,7 +486,7 @@ def bookmarklet_add_ticket() -> str:
         "favorite": request.form.get("favorite") == "on",
     }
 
-    if ticket_fields is None:
+    if entry_fields is None:
         categories = db.execute("SELECT id, name FROM categories ORDER BY name ASC").fetchall()
         return render_template(
             "bookmarklet_form.html",
@@ -497,13 +497,13 @@ def bookmarklet_add_ticket() -> str:
             form_values=form_values,
         )
 
-    link, category_id, description, ai_analysis, date_value, shared_with_manager, favorite, tags = ticket_fields
+    link, category_id, description, notes, date_value, shared_with_manager, favorite, tags = entry_fields
     cursor = db.execute(
         """
         INSERT INTO tickets (link, category_id, description, ai_analysis, date, shared_with_manager, favorite)
         VALUES (?, ?, ?, ?, ?, ?, ?)
         """,
-        (link, category_id, description, ai_analysis, date_value, shared_with_manager, favorite),
+        (link, category_id, description, notes, date_value, shared_with_manager, favorite),
     )
     _sync_ticket_tags(db, cursor.lastrowid, tags)
     db.commit()
@@ -511,7 +511,7 @@ def bookmarklet_add_ticket() -> str:
     form_values.update(
         {
             "description": "",
-            "ai_analysis": "",
+            "notes": "",
             "tags": "",
             "new_category_name": "",
             "shared_with_manager": False,
@@ -531,11 +531,11 @@ def bookmarklet_add_ticket() -> str:
 
 @app.route("/tickets/<int:ticket_id>/edit", methods=["POST"])
 def edit_ticket(ticket_id: int) -> Any:
-    ticket_fields = _validated_ticket_fields(request.form)
-    if ticket_fields is None:
+    entry_fields = _validated_entry_fields(request.form)
+    if entry_fields is None:
         return redirect(url_for("index", edit_id=ticket_id))
 
-    link, category_id, description, ai_analysis, date_value, shared_with_manager, favorite, tags = ticket_fields
+    link, category_id, description, notes, date_value, shared_with_manager, favorite, tags = entry_fields
 
     db = get_db()
     db.execute(
@@ -550,7 +550,7 @@ def edit_ticket(ticket_id: int) -> Any:
             favorite = ?
         WHERE id = ?
         """,
-        (link, category_id, description, ai_analysis, date_value, shared_with_manager, favorite, ticket_id),
+        (link, category_id, description, notes, date_value, shared_with_manager, favorite, ticket_id),
     )
     _sync_ticket_tags(db, ticket_id, tags)
     db.commit()

--- a/templates/bookmarklet_form.html
+++ b/templates/bookmarklet_form.html
@@ -135,11 +135,11 @@
   </style>
 </head>
 <body>
-  <h1>Quick Add Ticket</h1>
-  <p>This form is intended for bookmarklet usage. It pre-fills the current page URL as the ticket link.</p>
+  <h1>Quick Add Entry</h1>
+  <p>This form is intended for bookmarklet usage. It pre-fills the current page URL as the entry link.</p>
 
   {% if success %}
-    <div class="message success">Ticket saved successfully. This window will close automatically.</div>
+    <div class="message success">Entry saved successfully. This window will close automatically.</div>
   {% endif %}
 
   {% if error %}
@@ -147,7 +147,7 @@
   {% endif %}
 
   <form method="post" action="{{ url_for('bookmarklet_add_ticket') }}">
-    <label for="link">Ticket Link</label>
+    <label for="link">Entry Link</label>
     <input id="link" name="link" type="url" value="{{ form_values['link'] }}" required />
 
     <label for="category_id">Category</label>
@@ -173,7 +173,7 @@
     <textarea id="description" name="description" required>{{ form_values['description'] }}</textarea>
 
     <label for="ai_analysis">Notes</label>
-    <textarea id="ai_analysis" name="ai_analysis">{{ form_values['ai_analysis'] }}</textarea>
+    <textarea id="ai_analysis" name="ai_analysis">{{ form_values['notes'] }}</textarea>
 
     <label for="tags">Tags</label>
     <input id="tags" name="tags" type="hidden" value="{{ form_values['tags'] }}" />
@@ -194,7 +194,7 @@
       Favorite
     </label>
 
-    <button type="submit">Save Ticket</button>
+    <button type="submit">Save Entry</button>
   </form>
 
   <script>

--- a/templates/index.html
+++ b/templates/index.html
@@ -80,7 +80,7 @@
     input::placeholder, textarea::placeholder { color: #64748b; }
     input:focus, select:focus, textarea:focus { outline: 2px solid rgba(56, 189, 248, 0.45); border-color: var(--primary); }
     textarea { min-height: 80px; resize: vertical; }
-    .analysis-input { min-height: 180px; }
+    .notes-input { min-height: 180px; }
 
     .inline { display: flex; align-items: center; gap: 0.5rem; margin: 0.5rem 0; }
     .inline input { width: auto; accent-color: var(--primary); }
@@ -152,8 +152,8 @@
 
     .date-column { width: 120px; white-space: nowrap; }
     .manager-column, .favorite-column { width: 90px; text-align: center; }
-    .ticket-link-cell, .analysis-cell, .actions-cell { text-align: center; vertical-align: middle; }
-    .ticket-link-cell .btn, .analysis-cell .btn { min-width: 88px; text-align: center; }
+    .entry-link-cell, .notes-cell, .actions-cell { text-align: center; vertical-align: middle; }
+    .entry-link-cell .btn, .notes-cell .btn { min-width: 88px; text-align: center; }
 
     .actions { display: flex; gap: 0.5rem; align-items: center; justify-content: center; flex-wrap: wrap; }
     .actions a { text-decoration: none; }
@@ -291,7 +291,7 @@
       <textarea id="description" name="description" required></textarea>
 
       <label for="ai_analysis">Notes</label>
-      <textarea id="ai_analysis" class="analysis-input" name="ai_analysis" placeholder="Add notes"></textarea>
+      <textarea id="ai_analysis" class="notes-input" name="ai_analysis" placeholder="Add notes"></textarea>
 
       <label for="tags">Tags</label>
       <input id="tags" name="tags" type="hidden" />
@@ -336,7 +336,7 @@
     <textarea id="edit_description" name="description" required>{{ ticket_to_edit['description'] }}</textarea>
 
     <label for="edit_ai_analysis">Notes</label>
-    <textarea id="edit_ai_analysis" class="analysis-input" name="ai_analysis" placeholder="Add notes">{{ ticket_to_edit['ai_analysis'] }}</textarea>
+    <textarea id="edit_ai_analysis" class="notes-input" name="ai_analysis" placeholder="Add notes">{{ ticket_to_edit['notes'] }}</textarea>
 
     <label for="edit_tags">Tags</label>
     <input id="edit_tags" name="tags" type="hidden" value="{{ ticket_to_edit['tags'] if ticket_to_edit else '' }}" />
@@ -421,18 +421,18 @@
     <tbody>
       {% for ticket in tickets %}
       <tr>
-        <td class="ticket-link-cell">
+        <td class="entry-link-cell">
           <a class="btn secondary" href="{{ ticket['link'] }}" target="_blank" rel="noopener">{{ ticket['link_label'] }}</a>
         </td>
         <td>{{ ticket['category'] }}</td>
         <td>{{ ticket['description'] }}</td>
         <td class="date-column">{{ ticket['display_date'] }}</td>
-        <td class="analysis-cell">
-          {% if ticket['ai_analysis'] %}
+        <td class="notes-cell">
+          {% if ticket['notes'] %}
             <button
               type="button"
               class="btn secondary"
-              data-notes="{{ ticket['ai_analysis']|e }}"
+              data-notes="{{ ticket['notes']|e }}"
             >
               Notes
             </button>
@@ -482,13 +482,13 @@
     </tbody>
   </table>
 
-  <div id="analysis-modal" class="modal hidden" role="dialog" aria-modal="true" aria-labelledby="analysis-modal-title">
+  <div id="notes-modal" class="modal hidden" role="dialog" aria-modal="true" aria-labelledby="notes-modal-title">
     <div class="modal-content">
       <div class="modal-header">
-        <h3 id="analysis-modal-title">Notes</h3>
-        <button id="close-analysis-modal" type="button">Close</button>
+        <h3 id="notes-modal-title">Notes</h3>
+        <button id="close-notes-modal" type="button">Close</button>
       </div>
-      <div id="analysis-content" style="padding: 1rem; overflow: auto; white-space: pre-wrap; line-height: 1.45;"></div>
+      <div id="notes-content" style="padding: 1rem; overflow: auto; white-space: pre-wrap; line-height: 1.45;"></div>
     </div>
   </div>
 
@@ -509,29 +509,29 @@
   </div>
 
   <script>
-    const analysisModal = document.getElementById('analysis-modal');
-    const analysisContent = document.getElementById('analysis-content');
-    const closeAnalysisModalButton = document.getElementById('close-analysis-modal');
+    const notesModal = document.getElementById('notes-modal');
+    const notesContent = document.getElementById('notes-content');
+    const closeNotesModalButton = document.getElementById('close-notes-modal');
     const categoryModal = document.getElementById('category-modal');
     const openCategoryModalButton = document.getElementById('open-category-modal');
     const closeCategoryModalButton = document.getElementById('close-category-modal');
 
     document.querySelectorAll('[data-notes]').forEach((button) => {
       button.addEventListener('click', () => {
-        analysisContent.textContent = button.dataset.notes || '';
-        analysisModal.classList.remove('hidden');
+        notesContent.textContent = button.dataset.notes || '';
+        notesModal.classList.remove('hidden');
       });
     });
 
-    function closeAnalysisModal() {
-      analysisModal.classList.add('hidden');
-      analysisContent.textContent = '';
+    function closeNotesModal() {
+      notesModal.classList.add('hidden');
+      notesContent.textContent = '';
     }
 
-    closeAnalysisModalButton.addEventListener('click', closeAnalysisModal);
-    analysisModal.addEventListener('click', (event) => {
-      if (event.target === analysisModal) {
-        closeAnalysisModal();
+    closeNotesModalButton.addEventListener('click', closeNotesModal);
+    notesModal.addEventListener('click', (event) => {
+      if (event.target === notesModal) {
+        closeNotesModal();
       }
     });
 
@@ -555,8 +555,8 @@
     });
 
     document.addEventListener('keydown', (event) => {
-      if (event.key === 'Escape' && !analysisModal.classList.contains('hidden')) {
-        closeAnalysisModal();
+      if (event.key === 'Escape' && !notesModal.classList.contains('hidden')) {
+        closeNotesModal();
       }
       if (event.key === 'Escape' && !categoryModal.classList.contains('hidden')) {
         closeCategoryModal();
@@ -571,10 +571,6 @@
       }
 
       const tags = [];
-      const existingTags = (hiddenInput.value || '')
-        .split(',')
-        .map((tag) => tag.trim())
-        .filter((tag) => tag);
 
       function syncHiddenInput() {
         hiddenInput.value = tags.join(', ');
@@ -606,6 +602,12 @@
         syncHiddenInput();
       }
 
+      function setTags(rawTags) {
+        tags.length = 0;
+        parseTags(rawTags).forEach((tag) => tags.push(tag));
+        renderTags();
+      }
+
       function addTag(rawTag) {
         const tag = (rawTag || '').trim();
         if (!tag) {
@@ -626,7 +628,7 @@
         tagInput.value = '';
       }
 
-      existingTags.forEach((tag) => addTag(tag));
+      setTags(hiddenInput.value);
 
       tagInput.addEventListener('keydown', (event) => {
         if (event.key === 'Tab') {
@@ -646,7 +648,8 @@
 
       renderTags();
 
-      editor.refreshTagBubbles = renderTags;
+      editor.setTags = setTags;
+      editor.refreshTagBubbles = () => setTags(hiddenInput.value);
     }
 
     document.querySelectorAll('[data-tag-editor]').forEach((editor) => {
@@ -681,8 +684,8 @@
           selectedTags.push(clickedTag);
           tagsFilterInput.value = selectedTags.join(', ');
           const editor = document.querySelector('[data-tag-editor][data-hidden-input-id="tags_filter"]');
-          if (editor && typeof editor.refreshTagBubbles === "function") {
-            editor.refreshTagBubbles();
+          if (editor && typeof editor.setTags === "function") {
+            editor.setTags(selectedTags.join(', '));
           }
         }
 


### PR DESCRIPTION
### Motivation
- Restore one-click tag filtering from tag chips which regressed because the tag-editor UI state wasn't being updated before submitting the filters form. 
- Replace remaining "analysis"/`ai_analysis` naming and ticket-specific wording with more readable `notes` and generic `entry` terminology for templates and helper names while keeping the DB column intact.

### Description
- Fix tag-chip click flow by adding `setTags(...)` to the tag editor and calling `editor.setTags(selectedTags.join(', '))` before form submit so the visible bubbles and hidden `tags_filter` input stay in sync (changes in `templates/index.html`).
- Rename front-end identifiers for readability: `analysis` → `notes` for CSS classes, modal IDs/variables, and template bindings; rename ticket link cell classes to `entry-link-cell` (changes in `templates/index.html` and `templates/bookmarklet_form.html`).
- Update backend helper and local variable names from ticket/analysis to entry/notes (`_ticket_link_label` → `_entry_link_label`, `_build_ticket_filters` → `_build_entry_filters`, `_validated_ticket_fields` → `_validated_entry_fields`) and alias the `ai_analysis` column as `notes` in SELECTs/exports so templates use `notes` while preserving DB compatibility (changes in `app.py`).
- Update user-facing wording in the bookmarklet and README from "Ticket" to generic "Entry" and adjust bookmarklet template binding for notes (changes in `templates/bookmarklet_form.html` and `README.md`).

### Testing
- `python -m compileall app.py` executed successfully.
- Started the app (`python app.py`) to validate startup and manual behavior checks passed.
- Inserted a test category into the DB via a small Python snippet to prepare test data and it succeeded.
- Playwright check automated script opened the running app, created an entry with tag `alpha`, clicked the `alpha` tag-chip, asserted the page URL contains `tags=alpha`, and captured a screenshot; the script completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b115732d4c832b85cac9c89c014ab3)