### PR TITLE
Expand description search to include ticket links

### DIFF
--- a/app.py
+++ b/app.py
@@ -188,8 +188,9 @@ def _build_entry_filters(args: Any) -> tuple[list[str], list[Any], dict[str, Any
     params: list[Any] = []
 
     if description_search:
-        where_clauses.append("LOWER(t.description) LIKE ?")
-        params.append(f"%{description_search.lower()}%")
+        where_clauses.append("(LOWER(t.description) LIKE ? OR LOWER(t.link) LIKE ?)")
+        search_value = f"%{description_search.lower()}%"
+        params.extend([search_value, search_value])
 
     if category_filter.isdigit():
         where_clauses.append("t.category_id = ?")

--- a/templates/index.html
+++ b/templates/index.html
@@ -378,7 +378,7 @@
 
   <div class="controls">
     <form method="get" action="{{ url_for('index') }}">
-      <input name="q" type="text" placeholder="Search description..." value="{{ description_search }}" />
+      <input name="q" type="text" placeholder="Search description or link..." value="{{ description_search }}" />
 
       <select id="category_id_filter" name="category_id">
         <option value="">All categories</option>


### PR DESCRIPTION
### Motivation
- Allow searching by ticket numbers or PS identifiers that appear in the `link` field so queries that reference a ticket URL will return matching entries.
- Make the UI placeholder explicit that the search covers both description text and links.

### Description
- Updated the search filter logic in `_build_entry_filters` to add `(LOWER(t.description) LIKE ? OR LOWER(t.link) LIKE ?)` when `q` is provided.
- Reused a single normalized search value and extended `params` with it twice via `params.extend([search_value, search_value])` for the two SQL placeholders.
- Updated the search input placeholder in `templates/index.html` from `"Search description..."` to `"Search description or link..."`.

### Testing
- Ran `python -m py_compile app.py` which completed successfully.
- Started the app with `python app.py` which launched the development server without errors.
- Executed a Playwright script to load the index page and capture a screenshot of the updated search field which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b11c645248832b8b4c24be2fcb34fc)