### PR TITLE
Add delete-category bubbles to Add Category modal

### DIFF
--- a/app.py
+++ b/app.py
@@ -578,6 +578,21 @@ def add_category() -> Any:
     return redirect(url_for("index"))
 
 
+@app.route("/categories/<int:category_id>/delete", methods=["POST"])
+def delete_category(category_id: int) -> Any:
+    db = get_db()
+    linked_ticket = db.execute(
+        "SELECT 1 FROM tickets WHERE category_id = ? LIMIT 1",
+        (category_id,),
+    ).fetchone()
+    if linked_ticket is not None:
+        return redirect(url_for("index"))
+
+    db.execute("DELETE FROM categories WHERE id = ?", (category_id,))
+    db.commit()
+    return redirect(url_for("index"))
+
+
 if __name__ == "__main__":
     init_db()
     app.run(debug=True, host="0.0.0.0", port=5000)

--- a/templates/index.html
+++ b/templates/index.html
@@ -252,6 +252,9 @@
     .tag-bubble.filter-tag { cursor: pointer; font-weight: 600; transition: background-color 0.1s ease-in-out; }
     .tag-bubble.filter-tag:hover { background: rgba(56, 189, 248, 0.24); }
     .tag-list { display: flex; flex-wrap: wrap; gap: 0.35rem; }
+    .category-manager-list { margin-top: 0.8rem; }
+    .category-manager-list .compact-form { border: 0; background: transparent; padding: 0; box-shadow: none; }
+    .category-manager-list .tag-bubble { cursor: pointer; }
 
     .small-modal-content {
       background: rgba(15, 23, 42, 0.96);
@@ -514,6 +517,25 @@
           <input id="name" name="name" type="text" placeholder="e.g. Investigation, Pack Support, Etc." required />
           <button type="submit">Add Category</button>
         </form>
+
+        <div class="category-manager-list">
+          <label>Delete Categories</label>
+          <div class="tag-list">
+            {% for category in categories %}
+              <form action="{{ url_for('delete_category', category_id=category['id']) }}" method="post" class="compact-form">
+                <button
+                  type="submit"
+                  class="tag-bubble"
+                  onclick="return confirm('Delete category {{ category['name']|e }}? This only works for unused categories.');"
+                >
+                  {{ category['name'] }} <span aria-hidden="true">×</span>
+                </button>
+              </form>
+            {% else %}
+              <span>—</span>
+            {% endfor %}
+          </div>
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
### Motivation
- Provide a way to delete categories from the Add Category UI, showing them as tag-like bubbles with an `×` affordance so category management matches the tag UX.
- Prevent accidental data loss by disallowing deletion of categories that are still referenced by tickets.

### Description
- Added a new backend endpoint `POST /categories/<int:category_id>/delete` that deletes a category only if no tickets reference it (it checks `tickets WHERE category_id = ?`).
- Extended the Add Category modal in `templates/index.html` with a **Delete Categories** section that renders each category as a bubble wired to the new delete route and uses a `confirm(...)` prompt before submitting.
- Reused existing tag bubble styling and added a small modal-specific CSS block (`.category-manager-list` rules) so the delete bubbles render inline and visually match tags.

### Testing
- Ran `python -m py_compile app.py` and it succeeded.
- Launched the app with `python app.py` and validated the category modal UI manually and via an automated Playwright run that opened the modal and captured a screenshot of the delete bubbles.
- Playwright/UI verification confirmed the modal renders the category bubbles and the delete forms are present; backend safety check prevents deleting categories that are still used by tickets.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b11df48160832b8b7a353675af1da0)