### PR TITLE
Add pagination and filtered entry count to main list

### DIFF
--- a/app.py
+++ b/app.py
@@ -275,6 +275,14 @@ def index() -> str:
     sort_by = request.args.get("sort_by", "date")
     order = request.args.get("order", "desc")
     edit_id = request.args.get("edit_id", "").strip()
+    page_value = request.args.get("page", "1").strip()
+
+    try:
+        page = max(1, int(page_value))
+    except ValueError:
+        page = 1
+
+    per_page = 25
 
     allowed_sort = {"date": "t.date", "category": "c.name"}
     sort_column = allowed_sort.get(sort_by, "t.date")
@@ -285,6 +293,20 @@ def index() -> str:
     where_sql = f"WHERE {' AND '.join(where_clauses)}" if where_clauses else ""
 
     db = get_db()
+    total_count = db.execute(
+        f"""
+        SELECT COUNT(*) AS total
+        FROM tickets t
+        JOIN categories c ON t.category_id = c.id
+        {where_sql}
+        """,
+        params,
+    ).fetchone()["total"]
+
+    total_pages = max(1, (total_count + per_page - 1) // per_page)
+    page = min(page, total_pages)
+    offset = (page - 1) * per_page
+
     ticket_rows = db.execute(
         f"""
         SELECT t.id, t.link, c.name AS category, t.description, t.date,
@@ -297,8 +319,9 @@ def index() -> str:
         {where_sql}
         GROUP BY t.id
         ORDER BY {sort_column} {sort_order}, t.id DESC
+        LIMIT ? OFFSET ?
         """,
-        params,
+        [*params, per_page, offset],
     ).fetchall()
 
     tickets = []
@@ -338,6 +361,10 @@ def index() -> str:
         "index.html",
         tickets=tickets,
         categories=categories,
+        total_count=total_count,
+        page=page,
+        total_pages=total_pages,
+        per_page=per_page,
         sort_by=sort_by,
         order=order,
         **filter_state,

--- a/templates/index.html
+++ b/templates/index.html
@@ -124,6 +124,12 @@
 
     .controls { margin: 1.2rem 0; }
 
+    .count-label {
+      margin: 0 0 0.6rem;
+      color: var(--muted);
+      font-weight: 600;
+    }
+
     .controls form {
       display: grid;
       grid-template-columns: 2fr 1fr 1fr 1fr 1fr 1fr 1fr auto auto;
@@ -266,6 +272,19 @@
 
     .small-modal-body { padding: 1rem; }
 
+    .pagination {
+      margin-top: 1rem;
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      flex-wrap: wrap;
+    }
+
+    .pagination span {
+      color: var(--muted);
+      font-weight: 600;
+    }
+
     @media (max-width: 1100px) {
       .controls form { grid-template-columns: 1fr 1fr; }
       .controls form .btn { width: 100%; }
@@ -380,6 +399,7 @@
   <h2>Saved Entries</h2>
 
   <div class="controls">
+    <p class="count-label">Count: {{ total_count }}</p>
     <form method="get" action="{{ url_for('index') }}">
       <input name="q" type="text" placeholder="Search description or link..." value="{{ description_search }}" />
 
@@ -479,6 +499,7 @@
               <input type="hidden" name="tags" value="{{ tag_filter }}" />
               <input type="hidden" name="date_from" value="{{ date_from }}" />
               <input type="hidden" name="date_to" value="{{ date_to }}" />
+              <input type="hidden" name="page" value="{{ page }}" />
               <button class="btn secondary" type="submit">Edit</button>
             </form>
             <form action="{{ url_for('delete_ticket', ticket_id=ticket['id']) }}" method="post">
@@ -494,6 +515,30 @@
       {% endfor %}
     </tbody>
   </table>
+
+  {% if total_pages > 1 %}
+  <div class="pagination">
+    {% if page > 1 %}
+      <a
+        class="btn secondary"
+        href="{{ url_for('index', page=page-1, sort_by=sort_by, order=order, q=description_search, category_id=category_filter, shared_only=1 if shared_only else 0, favorite_only=1 if favorite_only else 0, tags=tag_filter, date_from=date_from, date_to=date_to) }}"
+      >
+        Previous
+      </a>
+    {% endif %}
+
+    <span>Page {{ page }} of {{ total_pages }}</span>
+
+    {% if page < total_pages %}
+      <a
+        class="btn secondary"
+        href="{{ url_for('index', page=page+1, sort_by=sort_by, order=order, q=description_search, category_id=category_filter, shared_only=1 if shared_only else 0, favorite_only=1 if favorite_only else 0, tags=tag_filter, date_from=date_from, date_to=date_to) }}"
+      >
+        Next
+      </a>
+    {% endif %}
+  </div>
+  {% endif %}
 
   <div id="notes-modal" class="modal hidden" role="dialog" aria-modal="true" aria-labelledby="notes-modal-title">
     <div class="modal-content">


### PR DESCRIPTION
### Motivation
- Improve usability by limiting the main entries list to a manageable default page size and showing how many results match the current filters.
- Preserve the current filter/sort state when navigating pages or opening an entry for edit.

### Description
- Added server-side pagination logic to the index route with a default page size of `25` and input validation for the `page` query parameter. 
- Computed a filter-aware `total_count` and `total_pages` and passed `total_count`, `page`, and `total_pages` into the template.
- Updated the main SQL query to use `LIMIT ? OFFSET ?` and applied `per_page`/`offset` parameters for paging.
- Enhanced `templates/index.html` to render a `Count: {{ total_count }}` label, Previous/Next pagination controls that preserve all current filters/sort query params, and a hidden `page` input on the Edit form so the active page is preserved when editing.

### Testing
- Ran `python -m py_compile app.py` which succeeded with no syntax errors.
- Launched the app with `python app.py` and performed a manual runtime check; UI updated correctly and a full-page screenshot of the changed UI was captured to validate the count and pagination controls.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b11f14e824832bb7cab6578a3e556a)