### PR TITLE
Add duplicate detection and merge workflow for tickets (backend + UI)

### DIFF
--- a/app.py
+++ b/app.py
@@ -323,6 +323,61 @@ def _validated_entry_fields(form: Any) -> tuple[str, str, str, str, str, int, in
     )
 
 
+def _find_potential_duplicates(
+    db: sqlite3.Connection,
+    link: str,
+    exclude_ticket_id: int | None = None,
+) -> list[dict[str, Any]]:
+    normalized_link = link.strip().lower()
+    if not normalized_link:
+        return []
+
+    where_parts = ["LOWER(t.link) = ?"]
+    params: list[Any] = [normalized_link]
+
+    if exclude_ticket_id is not None:
+        where_parts.append("t.id != ?")
+        params.append(exclude_ticket_id)
+
+    rows = db.execute(
+        f"""
+        SELECT t.id, t.link, t.category_id, t.description, t.ai_analysis AS notes, t.date,
+               t.shared_with_manager, t.favorite,
+               c.name AS category,
+               COALESCE(GROUP_CONCAT(tg.name, ', '), '') AS tags
+        FROM tickets t
+        JOIN categories c ON c.id = t.category_id
+        LEFT JOIN ticket_tags tt ON tt.ticket_id = t.id
+        LEFT JOIN tags tg ON tg.id = tt.tag_id
+        WHERE {' AND '.join(where_parts)}
+        GROUP BY t.id
+        ORDER BY t.date DESC, t.id DESC
+        LIMIT 5
+        """,
+        params,
+    ).fetchall()
+
+    duplicates: list[dict[str, Any]] = []
+    for row in rows:
+        duplicates.append(
+            {
+                "id": row["id"],
+                "link": row["link"],
+                "category_id": row["category_id"],
+                "description": row["description"],
+                "notes": row["notes"],
+                "date": row["date"],
+                "display_date": _human_readable_date(row["date"]),
+                "shared_with_manager": bool(row["shared_with_manager"]),
+                "favorite": bool(row["favorite"]),
+                "category": row["category"],
+                "tags": row["tags"],
+            }
+        )
+
+    return duplicates
+
+
 @app.route("/favicon.ico")
 def favicon() -> Response:
     return redirect(url_for("static", filename="favicon.ico"))
@@ -515,8 +570,45 @@ def add_ticket() -> Any:
         return redirect(url_for("index"))
 
     link, category_id, description, notes, date_value, shared_with_manager, favorite, tags = entry_fields
+    duplicate_action = request.form.get("duplicate_action", "").strip()
+    merge_target_id = request.form.get("merge_target_id", "").strip()
 
     db = get_db()
+
+    if duplicate_action != "continue":
+        potential_duplicates = _find_potential_duplicates(db, link)
+        if potential_duplicates and duplicate_action != "merge":
+            return redirect(url_for("index"))
+
+    if duplicate_action == "merge" and merge_target_id.isdigit():
+        target_id = int(merge_target_id)
+        merge_category_choice = request.form.get("merge_category_choice", "").strip()
+        target_ticket = db.execute(
+            "SELECT id, category_id FROM tickets WHERE id = ?",
+            (target_id,),
+        ).fetchone()
+        if target_ticket is None:
+            return redirect(url_for("index"))
+        final_category_id = target_ticket["category_id"] if merge_category_choice == "keep_existing" else category_id
+
+        db.execute(
+            """
+            UPDATE tickets
+            SET link = ?,
+                category_id = ?,
+                description = ?,
+                ai_analysis = ?,
+                date = ?,
+                shared_with_manager = ?,
+                favorite = ?
+            WHERE id = ?
+            """,
+            (link, final_category_id, description, notes, date_value, shared_with_manager, favorite, target_id),
+        )
+        _sync_ticket_tags(db, target_id, tags)
+        db.commit()
+        return redirect(url_for("index"))
+
     cursor = db.execute(
         """
         INSERT INTO tickets (link, category_id, description, ai_analysis, date, shared_with_manager, favorite)
@@ -527,6 +619,16 @@ def add_ticket() -> Any:
     _sync_ticket_tags(db, cursor.lastrowid, tags)
     db.commit()
     return redirect(url_for("index"))
+
+
+@app.route("/tickets/duplicates/check", methods=["POST"])
+def check_duplicates() -> Response:
+    link = request.form.get("link", "").strip()
+    if not link:
+        return jsonify({"success": False, "duplicates": [], "error": "Link is required."}), 400
+    db = get_db()
+    duplicates = _find_potential_duplicates(db, link)
+    return jsonify({"success": True, "duplicates": duplicates})
 
 
 @app.route("/bookmarklet/new", methods=["GET", "POST"])
@@ -591,14 +693,56 @@ def bookmarklet_add_ticket() -> str:
         )
 
     link, category_id, description, notes, date_value, shared_with_manager, favorite, tags = entry_fields
-    cursor = db.execute(
-        """
-        INSERT INTO tickets (link, category_id, description, ai_analysis, date, shared_with_manager, favorite)
-        VALUES (?, ?, ?, ?, ?, ?, ?)
-        """,
-        (link, category_id, description, notes, date_value, shared_with_manager, favorite),
-    )
-    _sync_ticket_tags(db, cursor.lastrowid, tags)
+    duplicate_action = request.form.get("duplicate_action", "").strip()
+    merge_target_id = request.form.get("merge_target_id", "").strip()
+    merge_category_choice = request.form.get("merge_category_choice", "").strip()
+
+    if duplicate_action != "continue":
+        potential_duplicates = _find_potential_duplicates(db, link)
+        if potential_duplicates and duplicate_action != "merge":
+            categories = _category_rows(db)
+            return render_template(
+                "bookmarklet_form.html",
+                categories=categories,
+                available_tags=available_tags,
+                today_date=date.today().isoformat(),
+                success=False,
+                error=True,
+                form_values=form_values,
+            )
+
+    if duplicate_action == "merge" and merge_target_id.isdigit():
+        target_id = int(merge_target_id)
+        target_ticket = db.execute(
+            "SELECT id, category_id FROM tickets WHERE id = ?",
+            (target_id,),
+        ).fetchone()
+        if target_ticket is not None:
+            final_category_id = target_ticket["category_id"] if merge_category_choice == "keep_existing" else category_id
+            db.execute(
+                """
+                UPDATE tickets
+                SET link = ?,
+                    category_id = ?,
+                    description = ?,
+                    ai_analysis = ?,
+                    date = ?,
+                    shared_with_manager = ?,
+                    favorite = ?
+                WHERE id = ?
+                """,
+                (link, final_category_id, description, notes, date_value, shared_with_manager, favorite, target_id),
+            )
+            _sync_ticket_tags(db, target_id, tags)
+    else:
+        cursor = db.execute(
+            """
+            INSERT INTO tickets (link, category_id, description, ai_analysis, date, shared_with_manager, favorite)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (link, category_id, description, notes, date_value, shared_with_manager, favorite),
+        )
+        _sync_ticket_tags(db, cursor.lastrowid, tags)
     db.commit()
 
     form_values.update(

--- a/templates/bookmarklet_form.html
+++ b/templates/bookmarklet_form.html
@@ -226,6 +226,60 @@
     }
 
     .tag-suggestions .tag-bubble:hover { background: rgba(56, 189, 248, 0.24); }
+    .modal.hidden { display: none; }
+    .modal {
+      position: fixed;
+      inset: 0;
+      background: rgba(2, 6, 23, 0.7);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 1rem;
+      z-index: 999;
+    }
+    .modal-content {
+      background: rgba(15, 23, 42, 0.96);
+      color: var(--text);
+      border: 1px solid var(--panel-border);
+      border-radius: 12px;
+      width: min(95vw, 920px);
+      max-height: 90vh;
+      overflow: auto;
+      box-shadow: var(--shadow);
+    }
+    .modal-header { padding: 0.75rem 1rem; border-bottom: 1px solid var(--panel-border); display: flex; justify-content: space-between; align-items: center; }
+    .modal-header h3 { margin: 0; color: #dbeafe; }
+    .duplicate-layout {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 1rem;
+      padding: 1rem;
+    }
+    .duplicate-column {
+      border: 1px solid rgba(148, 163, 184, 0.2);
+      border-radius: 10px;
+      padding: 0.75rem;
+      background: rgba(15, 23, 42, 0.4);
+    }
+    .duplicate-list {
+      max-height: 220px;
+      overflow: auto;
+      display: flex;
+      flex-direction: column;
+      gap: 0.4rem;
+      margin-bottom: 0.75rem;
+    }
+    .duplicate-option {
+      text-align: left;
+      padding: 0.6rem;
+      border-radius: 8px;
+      border: 1px solid rgba(125, 211, 252, 0.28);
+      background: rgba(15, 23, 42, 0.72);
+      color: #dbeafe;
+      cursor: pointer;
+    }
+    .duplicate-option.active { border-color: var(--primary); background: rgba(14, 165, 233, 0.18); }
+    .duplicate-actions { display: flex; gap: 0.5rem; justify-content: flex-end; padding: 0 1rem 1rem; }
 
     @media (max-width: 840px) {
       body { padding: 1rem; }
@@ -244,7 +298,7 @@
       <div class="message error">Please fill all required fields with valid values.</div>
     {% endif %}
 
-    <form method="post" action="{{ url_for('bookmarklet_add_ticket') }}">
+    <form method="post" action="{{ url_for('bookmarklet_add_ticket') }}" id="quick-add-form">
       <label for="link">Link</label>
       <input id="link" name="link" type="url" value="{{ form_values['link'] }}" required />
 
@@ -306,8 +360,48 @@
         Favorite
       </label>
 
+      <input type="hidden" name="duplicate_action" id="duplicate_action" value="" />
+      <input type="hidden" name="merge_target_id" id="merge_target_id" value="" />
+      <input type="hidden" name="merge_category_choice" id="merge_category_choice" value="" />
       <button class="btn" type="submit">Save Entry</button>
     </form>
+  </div>
+
+  <div id="duplicate-modal" class="modal hidden" role="dialog" aria-modal="true" aria-labelledby="duplicate-modal-title">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h3 id="duplicate-modal-title">Potential duplicate detected</h3>
+        <button id="close-duplicate-modal" type="button" class="btn secondary">Close</button>
+      </div>
+      <div class="duplicate-layout">
+        <div class="duplicate-column">
+          <h4>Existing ticket</h4>
+          <div id="duplicate-list" class="duplicate-list"></div>
+          <div id="selected-duplicate-preview" class="helper-text"></div>
+        </div>
+        <div class="duplicate-column">
+          <h4>Merge details (editable)</h4>
+          <label for="merge_link">Link</label>
+          <input id="merge_link" type="url" />
+          <label for="merge_description">Description</label>
+          <textarea id="merge_description"></textarea>
+          <label for="merge_notes">Notes</label>
+          <textarea id="merge_notes" class="notes-input"></textarea>
+          <label for="merge_tags">Tags (comma separated)</label>
+          <input id="merge_tags" type="text" />
+          <label for="merge_category_choice_select">Category</label>
+          <select id="merge_category_choice_select">
+            <option value="keep_existing">Keep existing ticket category</option>
+            <option value="use_selected">Use selected category from this form</option>
+          </select>
+        </div>
+      </div>
+      <div class="duplicate-actions">
+        <button id="duplicate-cancel" type="button" class="btn secondary">Cancel new submission</button>
+        <button id="duplicate-continue" type="button" class="btn secondary">Continue separately</button>
+        <button id="duplicate-merge" type="button" class="btn">Merge with selected ticket</button>
+      </div>
+    </div>
   </div>
 
   <script>
@@ -560,6 +654,138 @@
 
     document.querySelectorAll('[data-tag-editor]').forEach((editor) => {
       initializeTagEditor(editor);
+    });
+
+    const quickAddForm = document.getElementById('quick-add-form');
+    const duplicateActionInput = document.getElementById('duplicate_action');
+    const mergeTargetIdInput = document.getElementById('merge_target_id');
+    const mergeCategoryChoiceInput = document.getElementById('merge_category_choice');
+    const duplicateModal = document.getElementById('duplicate-modal');
+    const duplicateList = document.getElementById('duplicate-list');
+    const duplicatePreview = document.getElementById('selected-duplicate-preview');
+    const closeDuplicateModalButton = document.getElementById('close-duplicate-modal');
+    const duplicateCancelButton = document.getElementById('duplicate-cancel');
+    const duplicateContinueButton = document.getElementById('duplicate-continue');
+    const duplicateMergeButton = document.getElementById('duplicate-merge');
+    const mergeLinkInput = document.getElementById('merge_link');
+    const mergeDescriptionInput = document.getElementById('merge_description');
+    const mergeNotesInput = document.getElementById('merge_notes');
+    const mergeTagsInput = document.getElementById('merge_tags');
+    const mergeCategoryChoiceSelect = document.getElementById('merge_category_choice_select');
+    let pendingSubmission = null;
+    let selectedDuplicateId = null;
+
+    function closeDuplicateModal(resetAction = true) {
+      duplicateModal.classList.add('hidden');
+      duplicateList.innerHTML = '';
+      duplicatePreview.textContent = '';
+      pendingSubmission = null;
+      selectedDuplicateId = null;
+      if (resetAction) {
+        duplicateActionInput.value = '';
+        mergeTargetIdInput.value = '';
+        mergeCategoryChoiceInput.value = '';
+      }
+    }
+
+    function collectFormData(form) {
+      const formData = new FormData(form);
+      return {
+        link: String(formData.get('link') || '').trim(),
+        description: String(formData.get('description') || '').trim(),
+        ai_analysis: String(formData.get('ai_analysis') || ''),
+        tags: String(formData.get('tags') || ''),
+      };
+    }
+
+    function buildMergedText(existingText, newText) {
+      const existing = (existingText || '').trim();
+      const incoming = (newText || '').trim();
+      if (!existing) return incoming;
+      if (!incoming) return existing;
+      if (existing.toLowerCase() === incoming.toLowerCase()) return existing;
+      return `${existing}\n\n---\n${incoming}`;
+    }
+
+    function renderDuplicateCandidates(duplicates, submission) {
+      duplicateList.innerHTML = '';
+      duplicates.forEach((ticket, index) => {
+        const item = document.createElement('button');
+        item.type = 'button';
+        item.className = 'duplicate-option';
+        item.innerHTML = `#${ticket.id} • ${ticket.category}<br>${ticket.display_date}<br>${ticket.description}`;
+        item.addEventListener('click', () => {
+          selectedDuplicateId = ticket.id;
+          duplicateList.querySelectorAll('.duplicate-option').forEach((option) => option.classList.remove('active'));
+          item.classList.add('active');
+          duplicatePreview.textContent = `Selected ticket #${ticket.id}.`;
+          mergeLinkInput.value = submission.link || ticket.link || '';
+          mergeDescriptionInput.value = buildMergedText(ticket.description, submission.description);
+          mergeNotesInput.value = buildMergedText(ticket.notes, submission.ai_analysis);
+          const mergedTags = Array.from(new Set([...parseTags(ticket.tags), ...parseTags(submission.tags)]));
+          mergeTagsInput.value = mergedTags.join(', ');
+        });
+        duplicateList.appendChild(item);
+        if (index === 0) {
+          item.click();
+        }
+      });
+    }
+
+    if (quickAddForm) {
+      quickAddForm.addEventListener('submit', async (event) => {
+        if (duplicateActionInput.value === 'continue' || duplicateActionInput.value === 'merge') {
+          return;
+        }
+
+        event.preventDefault();
+        const submission = collectFormData(quickAddForm);
+        pendingSubmission = submission;
+        const payload = new URLSearchParams({ link: submission.link });
+        const response = await fetch('/tickets/duplicates/check', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          body: payload,
+        });
+
+        if (!response.ok) {
+          quickAddForm.submit();
+          return;
+        }
+
+        const result = await response.json();
+        if (!result.success || !result.duplicates || !result.duplicates.length) {
+          duplicateActionInput.value = 'continue';
+          quickAddForm.requestSubmit();
+          return;
+        }
+
+        renderDuplicateCandidates(result.duplicates, submission);
+        duplicateModal.classList.remove('hidden');
+      });
+    }
+
+    closeDuplicateModalButton.addEventListener('click', closeDuplicateModal);
+    duplicateCancelButton.addEventListener('click', closeDuplicateModal);
+    duplicateContinueButton.addEventListener('click', () => {
+      duplicateActionInput.value = 'continue';
+      closeDuplicateModal(false);
+      quickAddForm.requestSubmit();
+    });
+    duplicateMergeButton.addEventListener('click', () => {
+      if (!selectedDuplicateId || !pendingSubmission) {
+        return;
+      }
+
+      mergeTargetIdInput.value = String(selectedDuplicateId);
+      duplicateActionInput.value = 'merge';
+      mergeCategoryChoiceInput.value = mergeCategoryChoiceSelect.value;
+      document.getElementById('link').value = mergeLinkInput.value.trim();
+      document.getElementById('description').value = mergeDescriptionInput.value;
+      document.getElementById('ai_analysis').value = mergeNotesInput.value;
+      document.getElementById('tags').value = mergeTagsInput.value.trim();
+      closeDuplicateModal(false);
+      quickAddForm.requestSubmit();
     });
 
     {% if success %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -224,6 +224,39 @@
       line-height: 1.45;
       color: #dbeafe;
     }
+    .duplicate-layout {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 1rem;
+      padding: 1rem;
+      overflow: auto;
+    }
+    .duplicate-column {
+      border: 1px solid rgba(148, 163, 184, 0.2);
+      border-radius: 10px;
+      padding: 0.75rem;
+      background: rgba(15, 23, 42, 0.4);
+    }
+    .duplicate-column h4 { margin: 0 0 0.5rem; }
+    .duplicate-list {
+      max-height: 280px;
+      overflow: auto;
+      display: flex;
+      flex-direction: column;
+      gap: 0.4rem;
+      margin-bottom: 0.75rem;
+    }
+    .duplicate-option {
+      text-align: left;
+      padding: 0.6rem;
+      border-radius: 8px;
+      border: 1px solid rgba(125, 211, 252, 0.28);
+      background: rgba(15, 23, 42, 0.72);
+      color: #dbeafe;
+      cursor: pointer;
+    }
+    .duplicate-option.active { border-color: var(--primary); background: rgba(14, 165, 233, 0.18); }
+    .duplicate-actions { display: flex; gap: 0.5rem; justify-content: flex-end; padding: 0 1rem 1rem; }
 
     .field-with-button { display: flex; gap: 0.5rem; align-items: center; }
     .field-with-button select { flex: 1; }
@@ -338,7 +371,7 @@
   <h1>PackTracker</h1>
 
   <div class="layout">
-    <form action="{{ url_for('add_ticket') }}" method="post">
+    <form action="{{ url_for('add_ticket') }}" method="post" id="add-ticket-form">
       <details class="add-ticket-panel">
         <summary>Add New Entry</summary>
       <label for="link">Link</label>
@@ -394,6 +427,9 @@
         Favorite
       </label>
 
+      <input type="hidden" name="duplicate_action" id="duplicate_action" value="" />
+      <input type="hidden" name="merge_target_id" id="merge_target_id" value="" />
+      <input type="hidden" name="merge_category_choice" id="merge_category_choice" value="" />
       <button class="btn" type="submit">Save Entry</button>
       </details>
     </form>
@@ -618,6 +654,43 @@
     </div>
   </div>
 
+  <div id="duplicate-modal" class="modal hidden" role="dialog" aria-modal="true" aria-labelledby="duplicate-modal-title">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h3 id="duplicate-modal-title">Potential duplicate detected</h3>
+        <button id="close-duplicate-modal" type="button">Close</button>
+      </div>
+      <div class="duplicate-layout">
+        <div class="duplicate-column">
+          <h4>Existing ticket</h4>
+          <div id="duplicate-list" class="duplicate-list"></div>
+          <div id="selected-duplicate-preview" class="helper-text"></div>
+        </div>
+        <div class="duplicate-column">
+          <h4>Merge details (editable)</h4>
+          <label for="merge_link">Link</label>
+          <input id="merge_link" type="url" />
+          <label for="merge_description">Description</label>
+          <textarea id="merge_description"></textarea>
+          <label for="merge_notes">Notes</label>
+          <textarea id="merge_notes" class="notes-input"></textarea>
+          <label for="merge_tags">Tags (comma separated)</label>
+          <input id="merge_tags" type="text" />
+          <label for="merge_category_choice_select">Category</label>
+          <select id="merge_category_choice_select">
+            <option value="keep_existing">Keep existing ticket category</option>
+            <option value="use_selected">Use selected category from this form</option>
+          </select>
+        </div>
+      </div>
+      <div class="duplicate-actions">
+        <button id="duplicate-cancel" type="button" class="btn danger">Cancel new submission</button>
+        <button id="duplicate-continue" type="button" class="btn secondary">Continue separately</button>
+        <button id="duplicate-merge" type="button" class="btn">Merge with selected ticket</button>
+      </div>
+    </div>
+  </div>
+
   <script>
     const notesModal = document.getElementById('notes-modal');
     const notesContent = document.getElementById('notes-content');
@@ -646,6 +719,152 @@
       if (event.key === 'Escape' && !notesModal.classList.contains('hidden')) {
         closeNotesModal();
       }
+    });
+
+    const addTicketForm = document.getElementById('add-ticket-form');
+    const duplicateActionInput = document.getElementById('duplicate_action');
+    const mergeTargetIdInput = document.getElementById('merge_target_id');
+    const mergeCategoryChoiceInput = document.getElementById('merge_category_choice');
+    const duplicateModal = document.getElementById('duplicate-modal');
+    const duplicateList = document.getElementById('duplicate-list');
+    const duplicatePreview = document.getElementById('selected-duplicate-preview');
+    const closeDuplicateModalButton = document.getElementById('close-duplicate-modal');
+    const duplicateCancelButton = document.getElementById('duplicate-cancel');
+    const duplicateContinueButton = document.getElementById('duplicate-continue');
+    const duplicateMergeButton = document.getElementById('duplicate-merge');
+    const mergeLinkInput = document.getElementById('merge_link');
+    const mergeDescriptionInput = document.getElementById('merge_description');
+    const mergeNotesInput = document.getElementById('merge_notes');
+    const mergeTagsInput = document.getElementById('merge_tags');
+    const mergeCategoryChoiceSelect = document.getElementById('merge_category_choice_select');
+    let pendingSubmission = null;
+    let selectedDuplicateId = null;
+
+    function closeDuplicateModal(resetAction = true) {
+      duplicateModal.classList.add('hidden');
+      duplicateList.innerHTML = '';
+      duplicatePreview.textContent = '';
+      pendingSubmission = null;
+      selectedDuplicateId = null;
+      if (resetAction) {
+        if (duplicateActionInput) duplicateActionInput.value = '';
+        if (mergeTargetIdInput) mergeTargetIdInput.value = '';
+        if (mergeCategoryChoiceInput) mergeCategoryChoiceInput.value = '';
+      }
+    }
+
+    function collectFormData(form) {
+      const formData = new FormData(form);
+      return {
+        link: String(formData.get('link') || '').trim(),
+        category_id: String(formData.get('category_id') || '').trim(),
+        description: String(formData.get('description') || '').trim(),
+        ai_analysis: String(formData.get('ai_analysis') || ''),
+        date: String(formData.get('date') || '').trim(),
+        tags: String(formData.get('tags') || ''),
+        shared_with_manager: formData.get('shared_with_manager') ? 'on' : '',
+        favorite: formData.get('favorite') ? 'on' : '',
+      };
+    }
+
+    function parseTagList(rawTags) {
+      return (rawTags || '').split(',').map((tag) => tag.trim()).filter((tag) => tag);
+    }
+
+    function buildMergedText(existingText, newText) {
+      const existing = (existingText || '').trim();
+      const incoming = (newText || '').trim();
+      if (!existing) return incoming;
+      if (!incoming) return existing;
+      if (existing.toLowerCase() === incoming.toLowerCase()) return existing;
+      return `${existing}\n\n---\n${incoming}`;
+    }
+
+    function renderDuplicateCandidates(duplicates, submission) {
+      duplicateList.innerHTML = '';
+      duplicates.forEach((ticket, index) => {
+        const item = document.createElement('button');
+        item.type = 'button';
+        item.className = 'duplicate-option';
+        item.innerHTML = `#${ticket.id} • ${ticket.category}<br>${ticket.display_date}<br>${ticket.description}`;
+        item.addEventListener('click', () => {
+          selectedDuplicateId = ticket.id;
+          duplicateList.querySelectorAll('.duplicate-option').forEach((option) => option.classList.remove('active'));
+          item.classList.add('active');
+          duplicatePreview.textContent = `Selected ticket #${ticket.id}. Review and edit the merged fields before saving.`;
+          mergeLinkInput.value = submission.link || ticket.link || '';
+          mergeDescriptionInput.value = buildMergedText(ticket.description, submission.description);
+          mergeNotesInput.value = buildMergedText(ticket.notes, submission.ai_analysis);
+          const mergedTags = Array.from(new Set([...parseTagList(ticket.tags), ...parseTagList(submission.tags)]));
+          mergeTagsInput.value = mergedTags.join(', ');
+        });
+        duplicateList.appendChild(item);
+        if (index === 0) {
+          item.click();
+        }
+      });
+    }
+
+    if (addTicketForm) {
+      addTicketForm.addEventListener('submit', async (event) => {
+        if (duplicateActionInput.value === 'continue' || duplicateActionInput.value === 'merge') {
+          return;
+        }
+
+        event.preventDefault();
+        const submission = collectFormData(addTicketForm);
+        pendingSubmission = submission;
+
+        const payload = new URLSearchParams(submission);
+        const response = await fetch('/tickets/duplicates/check', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          body: payload,
+        });
+
+        if (!response.ok) {
+          addTicketForm.submit();
+          return;
+        }
+
+        const result = await response.json();
+        if (!result.success || !result.duplicates || !result.duplicates.length) {
+          duplicateActionInput.value = 'continue';
+          addTicketForm.requestSubmit();
+          return;
+        }
+
+        renderDuplicateCandidates(result.duplicates, submission);
+        duplicateModal.classList.remove('hidden');
+      });
+    }
+
+    closeDuplicateModalButton.addEventListener('click', closeDuplicateModal);
+    duplicateCancelButton.addEventListener('click', closeDuplicateModal);
+    duplicateContinueButton.addEventListener('click', () => {
+      duplicateActionInput.value = 'continue';
+      closeDuplicateModal(false);
+      addTicketForm.requestSubmit();
+    });
+    duplicateMergeButton.addEventListener('click', () => {
+      if (!selectedDuplicateId || !pendingSubmission) {
+        return;
+      }
+
+      mergeTargetIdInput.value = String(selectedDuplicateId);
+      duplicateActionInput.value = 'merge';
+      mergeCategoryChoiceInput.value = mergeCategoryChoiceSelect.value;
+      document.getElementById('link').value = mergeLinkInput.value.trim();
+      document.getElementById('description').value = mergeDescriptionInput.value;
+      document.getElementById('ai_analysis').value = mergeNotesInput.value;
+      document.getElementById('tags').value = mergeTagsInput.value.trim();
+
+      const tagsEditor = document.querySelector('[data-tag-editor][data-hidden-input-id="tags"]');
+      if (tagsEditor && typeof tagsEditor.setTags === 'function') {
+        tagsEditor.setTags(mergeTagsInput.value.trim());
+      }
+      closeDuplicateModal(false);
+      addTicketForm.requestSubmit();
     });
 
 


### PR DESCRIPTION
### Motivation
- Prevent accidental duplicate ticket creation by checking existing tickets with the same link and offer a merge/continue workflow. 
- Allow merging incoming entry data into an existing ticket while choosing which category to keep and combining notes/tags.

### Description
- Added `_find_potential_duplicates` helper in `app.py` to query potential duplicate tickets by normalized link and return consolidated ticket info and tags.
- Added a new API endpoint `POST /tickets/duplicates/check` that returns potential duplicates as JSON for client-side checks.
- Extended `add_ticket` and `bookmarklet_add_ticket` flows to consult duplicates before inserting, support three actions (`continue`, `merge`, default cancelling on detection), and implement server-side merge logic that updates the target ticket and syncs tags via `_sync_ticket_tags`.
- Updated `templates/index.html` and `templates/bookmarklet_form.html` to include hidden fields for duplicate actions, a modal UI for showing duplicate candidates, and client-side JavaScript that requests `/tickets/duplicates/check`, renders candidates, allows selecting a target, previews merged fields, and either continues, cancels, or submits a merge.
- Added CSS and JavaScript utilities to build merged text for description/notes, merge tag lists, and wire modal controls into both the main add form and the bookmarklet quick-add form.

### Testing
- Ran the project's automated test suite with `pytest` and verified all tests passed. 
- Ran linting with `flake8` to ensure style checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd0fee362c832baa86bdf87aab033a)